### PR TITLE
Update HotShot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-compatibility-layer",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +237,16 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-377"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/curves?rev=677b4ae751a274037880ede86e9b6f30f62635af#677b4ae751a274037880ede86e9b6f30f62635af"
+dependencies = [
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
@@ -262,6 +281,17 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
+dependencies = [
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
@@ -273,11 +303,22 @@ dependencies = [
 
 [[package]]
 name = "ark-bw6-761"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/curves?rev=677b4ae751a274037880ede86e9b6f30f62635af#677b4ae751a274037880ede86e9b6f30f62635af"
+dependencies = [
+ "ark-bls12-377 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-bw6-761"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
 dependencies = [
- "ark-bls12-377",
+ "ark-bls12-377 0.4.0",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
@@ -312,6 +353,7 @@ dependencies = [
  "ark-std 0.3.0",
  "derivative",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -322,7 +364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-poly",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -335,14 +377,37 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bls12-377"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/curves?rev=677b4ae751a274037880ede86e9b6f30f62635af#677b4ae751a274037880ede86e9b6f30f62635af"
+dependencies = [
+ "ark-bls12-377 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
- "ark-bls12-377",
+ "ark-bls12-377 0.4.0",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
+dependencies = [
+ "ark-bls12-381 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
 ]
 
 [[package]]
@@ -359,11 +424,23 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bn254"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdc786b806fdbff4abebb08ec2fcb50cfe3941918e57120ab121228452903fd"
+dependencies = [
+ "ark-bn254 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-std 0.3.0",
+]
+
+[[package]]
+name = "ark-ed-on-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71892f265d01650e34988a546b37ea1d2ba1da162a639597a03d1550f26004d8"
 dependencies = [
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
@@ -383,6 +460,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
+ "rayon",
  "rustc_version 0.3.3",
  "zeroize",
 ]
@@ -466,6 +544,20 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
+dependencies = [
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "hashbrown 0.11.2",
+ "rayon",
+]
+
+[[package]]
+name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
@@ -476,6 +568,21 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "rayon",
+]
+
+[[package]]
+name = "ark-poly-commit"
+version = "0.3.0"
+source = "git+https://github.com/arkworks-rs/poly-commit/?rev=cafc05e39692bbc5c383990063ad851f0b94a553#cafc05e39692bbc5c383990063ad851f0b94a553"
+dependencies = [
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-poly 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-sponge",
+ "ark-std 0.3.0",
+ "derivative",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -548,6 +655,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-sponge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c7a8ce8c0b0dad619872efd707395884fc05f46e9b0e7ac3903b51fa0e59ac"
+dependencies = [
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "digest 0.9.0",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +677,7 @@ checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+ "rayon",
 ]
 
 [[package]]
@@ -846,6 +969,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite 0.2.10",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1054,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
+name = "atomic_enum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6227a8d6fdb862bcb100c4314d0d9579e5cd73fa6df31a2e6f6e1acd3c5f1207"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "atomic_store"
 version = "0.1.3"
 source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.3#9da9998dd8d92f61c5b78a8f0676d415e6fafe92"
@@ -918,6 +1074,17 @@ dependencies = [
  "glob",
  "serde",
  "snafu",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1226,6 +1393,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0827b011f6f8ab38590295339817b0d26f344aa4932c3ced71b45b0c54b4a9"
@@ -1244,7 +1426,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -1253,7 +1435,7 @@ version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.27",
@@ -1345,6 +1527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,6 +1616,9 @@ name = "crc-any"
 version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df"
+dependencies = [
+ "debug-helper",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1512,6 +1707,21 @@ checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd26c32de5307fd08aac445a75c43472b14559d5dccdfba8022dbcd075838ebc"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "chacha20poly1305 0.10.1",
+ "salsa20",
+ "x25519-dalek",
+ "xsalsa20poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1669,7 +1879,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1683,7 +1893,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.27",
 ]
 
@@ -1747,6 +1957,12 @@ dependencies = [
  "data-encoding",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "der-parser"
@@ -1990,7 +2206,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2031,6 +2247,11 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "espresso-systems-common"
+version = "0.1.1"
+source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.1.1#bd3f7b1bbb03269a499101048a06472401953dca"
 
 [[package]]
 name = "espresso-systems-common"
@@ -2364,6 +2585,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -2388,9 +2618,27 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -2465,11 +2713,11 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "ark-bls12-381 0.3.0",
  "ark-ec 0.3.0",
- "ark-ed-on-bls12-381",
+ "ark-ed-on-bls12-381 0.4.0",
  "ark-serialize 0.3.0",
  "ark-std 0.4.0",
  "async-compatibility-layer",
@@ -2492,11 +2740,13 @@ dependencies = [
  "hotshot-consensus",
  "hotshot-orchestrator",
  "hotshot-primitives",
+ "hotshot-task",
+ "hotshot-task-impls",
  "hotshot-types",
  "hotshot-utils",
  "hotshot-web-server",
  "itertools 0.10.5",
- "jf-primitives 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
+ "jf-primitives 0.4.0-pre.0",
  "libp2p",
  "libp2p-identity",
  "libp2p-networking",
@@ -2515,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "hotshot-centralized-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "async-compatibility-layer",
  "async-std",
@@ -2537,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "hotshot-consensus"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2559,14 +2809,14 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
  "async-trait",
  "bincode",
  "blake3",
- "clap",
+ "clap 4.3.17",
  "futures",
  "hotshot-types",
  "hotshot-utils",
@@ -2586,15 +2836,16 @@ dependencies = [
 [[package]]
 name = "hotshot-primitives"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/hotshot-primitives.git?branch=update_jellyfish_0.4.0_pre.0#4b139286575cdc1a57a52fffd2f9933e67d86743"
+source = "git+https://github.com/EspressoSystems/hotshot-primitives?branch=hotshot-compat#bf859a899f2c9a8590a85e5e4e1f0216afb43a2b"
 dependencies = [
  "anyhow",
+ "ark-bls12-377 0.4.0",
  "ark-bls12-381 0.4.0",
- "ark-bn254",
+ "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-pallas",
- "ark-poly",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "bincode",
@@ -2604,8 +2855,9 @@ dependencies = [
  "displaydoc",
  "ethereum-types",
  "generic-array",
- "jf-primitives 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f)",
- "jf-utils 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f)",
+ "jf-primitives 0.4.0-pre.0",
+ "jf-relation",
+ "jf-utils 0.4.0-pre.0",
  "serde",
  "sha3",
  "tagged-base64 0.3.0",
@@ -2622,7 +2874,7 @@ dependencies = [
  "atomic_store",
  "backtrace-on-stack-overflow",
  "bincode",
- "clap",
+ "clap 4.3.17",
  "commit",
  "custom_debug",
  "derive_more",
@@ -2632,7 +2884,7 @@ dependencies = [
  "hotshot-types",
  "hotshot-utils",
  "itertools 0.10.5",
- "jf-primitives 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
+ "jf-primitives 0.4.0-pre.0",
  "portpicker",
  "prometheus",
  "rand 0.8.5",
@@ -2648,14 +2900,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "hotshot-task"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+dependencies = [
+ "async-compatibility-layer",
+ "async-lock",
+ "async-std",
+ "async-stream",
+ "async-trait",
+ "atomic_enum",
+ "commit",
+ "either",
+ "futures",
+ "nll",
+ "pin-project",
+ "serde",
+ "snafu",
+ "time 0.3.23",
+ "tracing",
+]
+
+[[package]]
+name = "hotshot-task-impls"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+dependencies = [
+ "async-compatibility-layer",
+ "async-lock",
+ "async-std",
+ "async-stream",
+ "async-trait",
+ "atomic_enum",
+ "bincode",
+ "commit",
+ "either",
+ "futures",
+ "hotshot-consensus",
+ "hotshot-task",
+ "hotshot-types",
+ "hotshot-utils",
+ "jf-primitives 0.1.3",
+ "nll",
+ "pin-project",
+ "rand_chacha 0.3.1",
+ "serde",
+ "snafu",
+ "time 0.3.23",
+ "tracing",
+]
+
+[[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "arbitrary",
  "ark-serialize 0.3.0",
  "ark-std 0.4.0",
  "async-compatibility-layer",
+ "async-lock",
  "async-std",
  "async-trait",
  "bincode",
@@ -2669,8 +2973,9 @@ dependencies = [
  "futures",
  "hex_fmt",
  "hotshot-primitives",
+ "hotshot-task",
  "hotshot-utils",
- "jf-primitives 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
+ "jf-primitives 0.4.0-pre.0",
  "libp2p-networking",
  "nll",
  "rand 0.8.5",
@@ -2684,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "bincode",
 ]
@@ -2692,19 +2997,19 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "ark-bls12-381 0.3.0",
  "async-compatibility-layer",
  "async-lock",
  "async-trait",
  "bincode",
- "clap",
+ "clap 4.3.17",
  "futures",
  "hotshot-primitives",
  "hotshot-types",
  "hotshot-utils",
- "jf-primitives 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
+ "jf-primitives 0.4.0-pre.0",
  "libp2p-core",
  "nll",
  "portpicker",
@@ -2974,7 +3279,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys",
 ]
@@ -3003,7 +3308,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "rustix 0.38.4",
  "windows-sys",
 ]
@@ -3062,21 +3367,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jf-plonk"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
+dependencies = [
+ "ark-bls12-377 0.3.0",
+ "ark-bls12-381 0.3.0",
+ "ark-bn254 0.3.0",
+ "ark-bw6-761 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-poly 0.3.0",
+ "ark-poly-commit",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "displaydoc",
+ "downcast-rs",
+ "espresso-systems-common 0.1.1",
+ "itertools 0.10.5",
+ "jf-rescue",
+ "jf-utils 0.1.3",
+ "merlin",
+ "num-bigint",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "jf-primitives"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
+dependencies = [
+ "ark-bls12-377 0.3.0",
+ "ark-bls12-381 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ed-on-bls12-377 0.3.0",
+ "ark-ed-on-bls12-381 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "crypto_box",
+ "derivative",
+ "digest 0.10.7",
+ "displaydoc",
+ "espresso-systems-common 0.1.1",
+ "generic-array",
+ "itertools 0.10.5",
+ "jf-plonk",
+ "jf-rescue",
+ "jf-utils 0.1.3",
+ "rand_chacha 0.3.1",
+ "rayon",
+ "serde",
+ "sha2 0.10.7",
+ "zeroize",
+]
+
+[[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6#36dceb63aa5b452b9551c0139bc5512d17f780cf"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
 dependencies = [
- "ark-bls12-377",
+ "anyhow",
+ "ark-bls12-377 0.4.0",
  "ark-bls12-381 0.4.0",
- "ark-bn254",
- "ark-bw6-761",
+ "ark-bn254 0.4.0",
+ "ark-bw6-761 0.4.0",
  "ark-crypto-primitives",
  "ark-ec 0.4.2",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-381",
- "ark-ed-on-bn254",
+ "ark-ed-on-bls12-377 0.4.0",
+ "ark-ed-on-bls12-381 0.4.0",
+ "ark-ed-on-bn254 0.4.0",
  "ark-ff 0.4.2",
- "ark-poly",
+ "ark-pallas",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "blst",
@@ -3087,9 +3454,10 @@ dependencies = [
  "displaydoc",
  "espresso-systems-common 0.4.0",
  "generic-array",
+ "hashbrown 0.13.2",
  "itertools 0.10.5",
- "jf-relation 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
- "jf-utils 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
+ "jf-relation",
+ "jf-utils 0.4.0-pre.0",
  "merlin",
  "num-bigint",
  "num-traits",
@@ -3098,109 +3466,84 @@ dependencies = [
  "serde",
  "sha2 0.10.7",
  "sha3",
- "tagged-base64 0.3.0",
+ "tagged-base64 0.3.3",
  "typenum",
  "zeroize",
 ]
 
 [[package]]
-name = "jf-primitives"
+name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f#c07a87f1469aaf761a3e909e9bd8b692b8ed6740"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
 dependencies = [
- "ark-bls12-377",
+ "ark-bls12-377 0.4.0",
  "ark-bls12-381 0.4.0",
- "ark-bn254",
- "ark-bw6-761",
- "ark-crypto-primitives",
+ "ark-bn254 0.4.0",
+ "ark-bw6-761 0.4.0",
  "ark-ec 0.4.2",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-381",
- "ark-ed-on-bn254",
  "ark-ff 0.4.2",
- "ark-poly",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "blst",
- "chacha20poly1305 0.10.1",
- "crypto_kx",
  "derivative",
- "digest 0.10.7",
  "displaydoc",
- "espresso-systems-common 0.4.0",
+ "downcast-rs",
+ "dyn-clone",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "jf-utils 0.4.0-pre.0",
+ "num-bigint",
+ "rand_chacha 0.3.1",
+ "rayon",
+]
+
+[[package]]
+name = "jf-rescue"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
+dependencies = [
+ "ark-bls12-377 0.3.0",
+ "ark-bls12-381 0.3.0",
+ "ark-bn254 0.3.0",
+ "ark-bw6-761 0.3.0",
+ "ark-ec 0.3.0",
+ "ark-ed-on-bls12-377 0.3.0",
+ "ark-ed-on-bls12-381 0.3.0",
+ "ark-ed-on-bn254 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "displaydoc",
  "generic-array",
- "itertools 0.10.5",
- "jf-relation 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f)",
- "jf-utils 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f)",
- "merlin",
- "num-bigint",
- "num-traits",
- "rand_chacha 0.3.1",
+ "jf-utils 0.1.3",
  "rayon",
  "serde",
- "sha2 0.10.7",
- "sha3",
- "tagged-base64 0.3.0",
- "typenum",
  "zeroize",
 ]
 
 [[package]]
-name = "jf-relation"
-version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6#36dceb63aa5b452b9551c0139bc5512d17f780cf"
+name = "jf-utils"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
 dependencies = [
- "ark-bls12-377",
- "ark-bls12-381 0.4.0",
- "ark-bn254",
- "ark-bw6-761",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "displaydoc",
- "downcast-rs",
- "dyn-clone",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "jf-utils 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6)",
- "num-bigint",
- "rand_chacha 0.3.1",
- "rayon",
-]
-
-[[package]]
-name = "jf-relation"
-version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f#c07a87f1469aaf761a3e909e9bd8b692b8ed6740"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-381 0.4.0",
- "ark-bn254",
- "ark-bw6-761",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "displaydoc",
- "downcast-rs",
- "dyn-clone",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "jf-utils 0.4.0-pre.0 (git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f)",
- "num-bigint",
- "rand_chacha 0.3.1",
- "rayon",
+ "anyhow",
+ "ark-ec 0.3.0",
+ "ark-ff 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "digest 0.10.7",
+ "jf-utils-derive",
+ "serde",
+ "sha2 0.10.7",
+ "snafu",
+ "tagged-base64 0.2.0",
 ]
 
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?rev=36dceb6#36dceb63aa5b452b9551c0139bc5512d17f780cf"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -3210,23 +3553,17 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.10.7",
- "tagged-base64 0.3.0",
+ "tagged-base64 0.3.3",
 ]
 
 [[package]]
-name = "jf-utils"
-version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?rev=c07a87f#c07a87f1469aaf761a3e909e9bd8b692b8ed6740"
+name = "jf-utils-derive"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "rayon",
- "serde",
- "sha2 0.10.7",
- "tagged-base64 0.3.0",
+ "ark-std 0.3.0",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3621,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=paper_benchmarking#ca62291a83b473bf8254cc1b02d45fbcaeefa90a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -3831,7 +4168,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "quote",
  "syn 1.0.109",
 ]
@@ -4450,7 +4787,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -4631,6 +4968,33 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "paw"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c0fc9b564dbc3dc2ed7c92c0c144f4de340aa94514ce2b446065417c4084e9"
+dependencies = [
+ "paw-attributes",
+ "paw-raw",
+]
+
+[[package]]
+name = "paw-attributes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "paw-raw"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
 
 [[package]]
 name = "pem"
@@ -5826,7 +6190,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5976,9 +6340,40 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "paw",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "strum"
@@ -5992,7 +6387,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6187,6 +6582,22 @@ dependencies = [
 
 [[package]]
 name = "tagged-base64"
+version = "0.2.0"
+source = "git+https://github.com/EspressoSystems/tagged-base64?tag=0.2.0#c393e135a14a585707012fe2d7f9790f6c5f61d9"
+dependencies = [
+ "base64 0.13.1",
+ "console_error_panic_hook",
+ "crc-any",
+ "futures-channel",
+ "js-sys",
+ "structopt",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tagged-base64"
 version = "0.2.4"
 source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.4#9b9a5fae1e2fd41db8573657cfe169e8284eb6c9"
 dependencies = [
@@ -6214,6 +6625,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagged-base64"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50189d4e81e3a3850799299cc908f28fb15740adccf8bd620f855be396e6e730"
+dependencies = [
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "base64 0.13.1",
+ "crc-any",
+ "serde",
+ "snafu",
+ "tagged-base64-macros 0.3.3",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "tagged-base64-macros"
 version = "0.2.0"
 source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.4#9b9a5fae1e2fd41db8573657cfe169e8284eb6c9"
@@ -6233,6 +6660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagged-base64-macros"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71636a96f40b6ea3d969182ce22ad8042d5a38839ce448fff3cef4dec80f7589"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6246,6 +6683,15 @@ checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
  "remove_dir_all",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -6307,7 +6753,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "clap",
+ "clap 4.3.17",
  "config",
  "derive_more",
  "dirs",
@@ -6779,6 +7225,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6891,6 +7349,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -7235,6 +7699,19 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.23",
+]
+
+[[package]]
+name = "xsalsa20poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a6dad357567f81cd78ee75f7c61f1b30bb2fe4390be8fb7c69e2ac8dffb6c7"
+dependencies = [
+ "aead 0.5.2",
+ "poly1305 0.8.0",
+ "salsa20",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,7 +2498,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "ark-bls12-381 0.3.0",
  "ark-ec 0.3.0",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "hotshot-centralized-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "async-compatibility-layer",
  "async-std",
@@ -2572,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "hotshot-consensus"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2709,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "arbitrary",
  "ark-serialize 0.3.0",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "bincode",
 ]
@@ -2782,7 +2782,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "ark-bls12-381 0.3.0",
  "async-compatibility-layer",
@@ -3154,7 +3154,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3174,6 +3174,7 @@ dependencies = [
  "blst",
  "chacha20poly1305 0.10.1",
  "crypto_kx",
+ "curve25519-dalek 4.0.0-rc.1",
  "derivative",
  "digest 0.10.7",
  "displaydoc",
@@ -3199,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -3225,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
+source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#58eb45ab189364a2538e5ccaa912a3afdabd2bd1"
 dependencies = [
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
@@ -3630,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#2830bf17b95b790791f99d3160a187d3119c1401"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,15 +163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,16 +228,6 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-377"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/curves?rev=677b4ae751a274037880ede86e9b6f30f62635af#677b4ae751a274037880ede86e9b6f30f62635af"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
@@ -281,17 +262,6 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
@@ -303,22 +273,11 @@ dependencies = [
 
 [[package]]
 name = "ark-bw6-761"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/curves?rev=677b4ae751a274037880ede86e9b6f30f62635af#677b4ae751a274037880ede86e9b6f30f62635af"
-dependencies = [
- "ark-bls12-377 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-bw6-761"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
 dependencies = [
- "ark-bls12-377 0.4.0",
+ "ark-bls12-377",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
@@ -353,7 +312,6 @@ dependencies = [
  "ark-std 0.3.0",
  "derivative",
  "num-traits",
- "rayon",
  "zeroize",
 ]
 
@@ -364,7 +322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-poly 0.4.2",
+ "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -377,37 +335,14 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bls12-377"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/curves?rev=677b4ae751a274037880ede86e9b6f30f62635af#677b4ae751a274037880ede86e9b6f30f62635af"
-dependencies = [
- "ark-bls12-377 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-ed-on-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
- "ark-bls12-377 0.4.0",
+ "ark-bls12-377",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-ed-on-bls12-381"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b7ada17db3854f5994e74e60b18e10e818594935ee7e1d329800c117b32970"
-dependencies = [
- "ark-bls12-381 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
 ]
 
 [[package]]
@@ -424,23 +359,11 @@ dependencies = [
 
 [[package]]
 name = "ark-ed-on-bn254"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdc786b806fdbff4abebb08ec2fcb50cfe3941918e57120ab121228452903fd"
-dependencies = [
- "ark-bn254 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-std 0.3.0",
-]
-
-[[package]]
-name = "ark-ed-on-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71892f265d01650e34988a546b37ea1d2ba1da162a639597a03d1550f26004d8"
 dependencies = [
- "ark-bn254 0.4.0",
+ "ark-bn254",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
@@ -460,7 +383,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rayon",
  "rustc_version 0.3.3",
  "zeroize",
 ]
@@ -544,20 +466,6 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0f78f47537c2f15706db7e98fe64cc1711dbf9def81218194e17239e53e5aa"
-dependencies = [
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "hashbrown 0.11.2",
- "rayon",
-]
-
-[[package]]
-name = "ark-poly"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
@@ -568,21 +476,6 @@ dependencies = [
  "derivative",
  "hashbrown 0.13.2",
  "rayon",
-]
-
-[[package]]
-name = "ark-poly-commit"
-version = "0.3.0"
-source = "git+https://github.com/arkworks-rs/poly-commit/?rev=cafc05e39692bbc5c383990063ad851f0b94a553#cafc05e39692bbc5c383990063ad851f0b94a553"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-serialize 0.3.0",
- "ark-sponge",
- "ark-std 0.3.0",
- "derivative",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -655,21 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-sponge"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c7a8ce8c0b0dad619872efd707395884fc05f46e9b0e7ac3903b51fa0e59ac"
-dependencies = [
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "digest 0.9.0",
- "rand_chacha 0.3.1",
-]
-
-[[package]]
 name = "ark-std"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,7 +555,6 @@ checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
- "rayon",
 ]
 
 [[package]]
@@ -772,7 +649,7 @@ dependencies = [
 [[package]]
 name = "async-compatibility-layer"
 version = "1.0.0"
-source = "git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.2.0#98bb98a754c6dc5ac1da0855db315e0ad0f5db5b"
+source = "git+https://github.com/EspressoSystems/async-compatibility-layer.git?tag=1.3.0#f5478b9b33b8c5b81bfc029c84de9079fc8a64f7"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -1074,17 +951,6 @@ dependencies = [
  "glob",
  "serde",
  "snafu",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1393,21 +1259,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0827b011f6f8ab38590295339817b0d26f344aa4932c3ced71b45b0c54b4a9"
@@ -1426,7 +1277,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
@@ -1435,7 +1286,7 @@ version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.27",
@@ -1527,16 +1378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,9 +1457,6 @@ name = "crc-any"
 version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df"
-dependencies = [
- "debug-helper",
-]
 
 [[package]]
 name = "crc32fast"
@@ -1707,21 +1545,6 @@ checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "crypto_box"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd26c32de5307fd08aac445a75c43472b14559d5dccdfba8022dbcd075838ebc"
-dependencies = [
- "aead 0.5.2",
- "chacha20 0.9.1",
- "chacha20poly1305 0.10.1",
- "salsa20",
- "x25519-dalek",
- "xsalsa20poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -1879,7 +1702,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
 ]
 
@@ -1893,7 +1716,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 2.0.27",
 ]
 
@@ -1957,12 +1780,6 @@ dependencies = [
  "data-encoding",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "debug-helper"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "der-parser"
@@ -2206,7 +2023,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2247,11 +2064,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "espresso-systems-common"
-version = "0.1.1"
-source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.1.1#bd3f7b1bbb03269a499101048a06472401953dca"
 
 [[package]]
 name = "espresso-systems-common"
@@ -2585,15 +2397,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -2618,27 +2421,9 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -2713,11 +2498,11 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "ark-bls12-381 0.3.0",
  "ark-ec 0.3.0",
- "ark-ed-on-bls12-381 0.4.0",
+ "ark-ed-on-bls12-381",
  "ark-serialize 0.3.0",
  "ark-std 0.4.0",
  "async-compatibility-layer",
@@ -2746,7 +2531,7 @@ dependencies = [
  "hotshot-utils",
  "hotshot-web-server",
  "itertools 0.10.5",
- "jf-primitives 0.4.0-pre.0",
+ "jf-primitives",
  "libp2p",
  "libp2p-identity",
  "libp2p-networking",
@@ -2765,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "hotshot-centralized-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "async-compatibility-layer",
  "async-std",
@@ -2787,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "hotshot-consensus"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2809,14 +2594,14 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
  "async-trait",
  "bincode",
  "blake3",
- "clap 4.3.17",
+ "clap",
  "futures",
  "hotshot-types",
  "hotshot-utils",
@@ -2839,13 +2624,13 @@ version = "0.1.0"
 source = "git+https://github.com/EspressoSystems/hotshot-primitives?branch=hotshot-compat#bf859a899f2c9a8590a85e5e4e1f0216afb43a2b"
 dependencies = [
  "anyhow",
- "ark-bls12-377 0.4.0",
+ "ark-bls12-377",
  "ark-bls12-381 0.4.0",
- "ark-bn254 0.4.0",
+ "ark-bn254",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-pallas",
- "ark-poly 0.4.2",
+ "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "bincode",
@@ -2855,9 +2640,9 @@ dependencies = [
  "displaydoc",
  "ethereum-types",
  "generic-array",
- "jf-primitives 0.4.0-pre.0",
+ "jf-primitives",
  "jf-relation",
- "jf-utils 0.4.0-pre.0",
+ "jf-utils",
  "serde",
  "sha3",
  "tagged-base64 0.3.0",
@@ -2874,7 +2659,7 @@ dependencies = [
  "atomic_store",
  "backtrace-on-stack-overflow",
  "bincode",
- "clap 4.3.17",
+ "clap",
  "commit",
  "custom_debug",
  "derive_more",
@@ -2884,7 +2669,7 @@ dependencies = [
  "hotshot-types",
  "hotshot-utils",
  "itertools 0.10.5",
- "jf-primitives 0.4.0-pre.0",
+ "jf-primitives",
  "portpicker",
  "prometheus",
  "rand 0.8.5",
@@ -2902,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2924,7 +2709,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -2940,7 +2725,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-types",
  "hotshot-utils",
- "jf-primitives 0.1.3",
+ "jf-primitives",
  "nll",
  "pin-project",
  "rand_chacha 0.3.1",
@@ -2953,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "arbitrary",
  "ark-serialize 0.3.0",
@@ -2975,7 +2760,7 @@ dependencies = [
  "hotshot-primitives",
  "hotshot-task",
  "hotshot-utils",
- "jf-primitives 0.4.0-pre.0",
+ "jf-primitives",
  "libp2p-networking",
  "nll",
  "rand 0.8.5",
@@ -2989,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "bincode",
 ]
@@ -2997,19 +2782,19 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "ark-bls12-381 0.3.0",
  "async-compatibility-layer",
  "async-lock",
  "async-trait",
  "bincode",
- "clap 4.3.17",
+ "clap",
  "futures",
  "hotshot-primitives",
  "hotshot-types",
  "hotshot-utils",
- "jf-primitives 0.4.0-pre.0",
+ "jf-primitives",
  "libp2p-core",
  "nll",
  "portpicker",
@@ -3279,7 +3064,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -3308,7 +3093,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.4",
  "windows-sys",
 ]
@@ -3367,83 +3152,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "jf-plonk"
-version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
-dependencies = [
- "ark-bls12-377 0.3.0",
- "ark-bls12-381 0.3.0",
- "ark-bn254 0.3.0",
- "ark-bw6-761 0.3.0",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-poly 0.3.0",
- "ark-poly-commit",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "displaydoc",
- "downcast-rs",
- "espresso-systems-common 0.1.1",
- "itertools 0.10.5",
- "jf-rescue",
- "jf-utils 0.1.3",
- "merlin",
- "num-bigint",
- "rand_chacha 0.3.1",
- "rayon",
- "serde",
- "sha3",
-]
-
-[[package]]
-name = "jf-primitives"
-version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
-dependencies = [
- "ark-bls12-377 0.3.0",
- "ark-bls12-381 0.3.0",
- "ark-ec 0.3.0",
- "ark-ed-on-bls12-377 0.3.0",
- "ark-ed-on-bls12-381 0.3.0",
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "crypto_box",
- "derivative",
- "digest 0.10.7",
- "displaydoc",
- "espresso-systems-common 0.1.1",
- "generic-array",
- "itertools 0.10.5",
- "jf-plonk",
- "jf-rescue",
- "jf-utils 0.1.3",
- "rand_chacha 0.3.1",
- "rayon",
- "serde",
- "sha2 0.10.7",
- "zeroize",
-]
-
-[[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
 dependencies = [
  "anyhow",
- "ark-bls12-377 0.4.0",
+ "ark-bls12-377",
  "ark-bls12-381 0.4.0",
- "ark-bn254 0.4.0",
- "ark-bw6-761 0.4.0",
+ "ark-bn254",
+ "ark-bw6-761",
  "ark-crypto-primitives",
  "ark-ec 0.4.2",
- "ark-ed-on-bls12-377 0.4.0",
- "ark-ed-on-bls12-381 0.4.0",
- "ark-ed-on-bn254 0.4.0",
+ "ark-ed-on-bls12-377",
+ "ark-ed-on-bls12-381",
+ "ark-ed-on-bn254",
  "ark-ff 0.4.2",
  "ark-pallas",
- "ark-poly 0.4.2",
+ "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "blst",
@@ -3457,7 +3182,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "itertools 0.10.5",
  "jf-relation",
- "jf-utils 0.4.0-pre.0",
+ "jf-utils",
  "merlin",
  "num-bigint",
  "num-traits",
@@ -3476,13 +3201,13 @@ name = "jf-relation"
 version = "0.4.0-pre.0"
 source = "git+https://github.com/EspressoSystems/jellyfish?branch=hotshot-compat#470a8330c744a1f2e6b543ae3f6ddf5a1622906d"
 dependencies = [
- "ark-bls12-377 0.4.0",
+ "ark-bls12-377",
  "ark-bls12-381 0.4.0",
- "ark-bn254 0.4.0",
- "ark-bw6-761 0.4.0",
+ "ark-bn254",
+ "ark-bw6-761",
  "ark-ec 0.4.2",
  "ark-ff 0.4.2",
- "ark-poly 0.4.2",
+ "ark-poly",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -3491,53 +3216,10 @@ dependencies = [
  "dyn-clone",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
- "jf-utils 0.4.0-pre.0",
+ "jf-utils",
  "num-bigint",
  "rand_chacha 0.3.1",
  "rayon",
-]
-
-[[package]]
-name = "jf-rescue"
-version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
-dependencies = [
- "ark-bls12-377 0.3.0",
- "ark-bls12-381 0.3.0",
- "ark-bn254 0.3.0",
- "ark-bw6-761 0.3.0",
- "ark-ec 0.3.0",
- "ark-ed-on-bls12-377 0.3.0",
- "ark-ed-on-bls12-381 0.3.0",
- "ark-ed-on-bn254 0.3.0",
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "displaydoc",
- "generic-array",
- "jf-utils 0.1.3",
- "rayon",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "jf-utils"
-version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
-dependencies = [
- "anyhow",
- "ark-ec 0.3.0",
- "ark-ff 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "digest 0.10.7",
- "jf-utils-derive",
- "serde",
- "sha2 0.10.7",
- "snafu",
- "tagged-base64 0.2.0",
 ]
 
 [[package]]
@@ -3554,16 +3236,6 @@ dependencies = [
  "serde",
  "sha2 0.10.7",
  "tagged-base64 0.3.3",
-]
-
-[[package]]
-name = "jf-utils-derive"
-version = "0.1.3"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.1.2-patch.1#06e5b4bb92723b934c4b3b6489a378651d7b7055"
-dependencies = [
- "ark-std 0.3.0",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3958,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#96eec095324f8323f87eddcb72940c3271e6647b"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=run_view_refactor#93f51b4145e439027c7fe8679133f2e5dab31eb8"
 dependencies = [
  "async-compatibility-layer",
  "async-lock",
@@ -4168,7 +3840,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "quote",
  "syn 1.0.109",
 ]
@@ -4787,7 +4459,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4968,33 +4640,6 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "paw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c0fc9b564dbc3dc2ed7c92c0c144f4de340aa94514ce2b446065417c4084e9"
-dependencies = [
- "paw-attributes",
- "paw-raw",
-]
-
-[[package]]
-name = "paw-attributes"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "paw-raw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
 
 [[package]]
 name = "pem"
@@ -6190,7 +5835,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6340,40 +5985,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "paw",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -6387,7 +6001,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -6582,22 +6196,6 @@ dependencies = [
 
 [[package]]
 name = "tagged-base64"
-version = "0.2.0"
-source = "git+https://github.com/EspressoSystems/tagged-base64?tag=0.2.0#c393e135a14a585707012fe2d7f9790f6c5f61d9"
-dependencies = [
- "base64 0.13.1",
- "console_error_panic_hook",
- "crc-any",
- "futures-channel",
- "js-sys",
- "structopt",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "tagged-base64"
 version = "0.2.4"
 source = "git+https://github.com/EspressoSystems/tagged-base64.git?tag=0.2.4#9b9a5fae1e2fd41db8573657cfe169e8284eb6c9"
 dependencies = [
@@ -6686,15 +6284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6753,7 +6342,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "clap 4.3.17",
+ "clap",
  "config",
  "derive_more",
  "dirs",
@@ -7225,18 +6814,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7349,12 +6926,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -7699,19 +7270,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time 0.3.23",
-]
-
-[[package]]
-name = "xsalsa20poly1305"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a6dad357567f81cd78ee75f7c61f1b30bb2fe4390be8fb7c69e2ac8dffb6c7"
-dependencies = [
- "aead 0.5.2",
- "poly1305 0.8.0",
- "salsa20",
- "subtle",
- "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 testing = ["rand", "tempdir", "jf-primitives"]
 
 [dependencies]
-async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.2.0", features = [
+async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-compatibility-layer.git", tag = "1.3.0", features = [
     "async-std-executor",
     "logging-utils",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "hotshot-query-service"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,15 +35,15 @@ custom_debug = "0.5"
 derive_more = "0.99"
 either = "1.8"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "paper_benchmarking", features = [
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "run_view_refactor", features = [
     "async-std-executor",
     "channel-async-std",
 ] }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "paper_benchmarking", features = [
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "run_view_refactor", features = [
     "async-std-executor",
     "channel-async-std",
 ] }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "paper_benchmarking" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "run_view_refactor" }
 itertools = "0.10"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
@@ -55,7 +55,7 @@ toml = "0.5"
 tracing = "0.1"
 
 # Dependencies enabled by feature "testing".
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", rev = "36dceb6", features = [
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", branch = "hotshot-compat", features = [
     "std",
 ], optional = true }
 rand = { version = "0.8", optional = true }

--- a/api/availability.toml
+++ b/api/availability.toml
@@ -92,6 +92,11 @@ may succeed but `block/i` may fail. However, once `block/i` succeeds, it is guar
 `block/i` will _eventually_ succeed, and return a block whose `hash` is the same as the
 `block_hash` from the corresponding leaf.
 
+HotShot consensus does not validate the blocks produced by block builders, and in particular it does
+not prohibit duplicate blocks. While each block has a unique height there may be multiple blocks at
+different heights with the same hash. In such cases, this endpoint will return the _earliest_ block
+with the requested hash.
+
 Returns
 ```
 {
@@ -124,6 +129,11 @@ Get a transaction by its `index` in the block at `height` or by its hash.
 If specified, `:height` and `:index` represent the block containing the transaction and the index
 of the transaction within the block, respectively. Otherwise, `:hash` is the hash of the
 transaction.
+
+HotShot consensus does not validate the transactions it sequences, and in particular it does not
+prohibit duplicate transactions. While each transaction has a unique position in the log (indicated
+by its height and index) there may be multiple transactions at different positions with the same
+hash. In such cases, this endpoint will return the _earliest_ transaction with the requested hash.
 
 The response includes the hash of the block containing this transaction as well as an application-
 defined inclusion proof relative to the block hash. Applications may use `proof` to prove that the

--- a/flake.lock
+++ b/flake.lock
@@ -178,11 +178,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1686018793,
-        "narHash": "sha256-3w+6dmVbFg4wJqDMjGmy4Ki5GclJx4AhzSEfAwtu6Aw=",
+        "lastModified": 1690252178,
+        "narHash": "sha256-9oEz822bvbHobfCUjJLDor2BqW3I5tycIauzDlzOALY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "32b17eeafe550935bd5ca1afd1717dcefcb97653",
+        "rev": "8d64353ca827002fb8459e44d49116c78d868eba",
         "type": "github"
       },
       "original": {

--- a/src/ledger_log.rs
+++ b/src/ledger_log.rs
@@ -142,7 +142,8 @@ impl<T: Serialize + DeserializeOwned + Clone> LedgerLog<T> {
         // placeholders.
         let len = self.store.iter().len();
         let target_len = std::cmp::max(index, len);
-        for _ in len..target_len {
+        for i in len..target_len {
+            tracing::debug!("storing placeholders for position {}/{target_len}", len + i);
             if let Err(err) = self.store_resource(None) {
                 warn!("Failed to store placeholder: {}", err);
                 return Err(err);
@@ -159,6 +160,7 @@ impl<T: Serialize + DeserializeOwned + Clone> LedgerLog<T> {
             // This is an object earlier in the chain that we are now receiving asynchronously.
             // Update the placeholder with the actual contents of the object.
             // TODO update persistent storage once AppendLog supports updates.
+            warn!("skipping out-of-order object; random inserts not yet supported");
 
             // Update the object in cache if necessary.
             if index >= self.cache_start {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! # Basic usage
 //!
 //! ```
-//! # use hotshot::types::HotShotHandle;
+//! # use hotshot::types::SystemContextHandle;
 //! # use hotshot_query_service::testing::mocks::{
 //! #   MockNodeImpl as AppNodeImpl, MockTypes as AppTypes,
 //! # };
@@ -84,11 +84,11 @@
 //!
 //! ```
 //! # use async_std::task::spawn;
-//! # use hotshot::types::HotShotHandle;
+//! # use hotshot::types::SystemContextHandle;
 //! # use hotshot_query_service::{data_source::QueryData, Error, Options};
 //! # use hotshot_query_service::testing::mocks::{MockTypes, MockNodeImpl};
 //! # use std::path::Path;
-//! # fn doc(storage_path: &Path, options: &Options, hotshot: HotShotHandle<MockTypes, MockNodeImpl>) -> Result<(), Error> {
+//! # fn doc(storage_path: &Path, options: &Options, hotshot: SystemContextHandle<MockTypes, MockNodeImpl>) -> Result<(), Error> {
 //! use hotshot_query_service::run_standalone_service;
 //!
 //! let query_data = QueryData::create(storage_path, ()).map_err(Error::internal)?;
@@ -336,7 +336,7 @@
 //! ```
 //! # use async_std::{sync::{Arc, RwLock}, task::spawn};
 //! # use atomic_store::{AtomicStore, AtomicStoreLoader};
-//! # use hotshot::types::HotShotHandle;
+//! # use hotshot::types::SystemContextHandle;
 //! # use hotshot_query_service::Error;
 //! # use hotshot_query_service::data_source::{UpdateDataSource, QueryData};
 //! # use hotshot_query_service::testing::mocks::{
@@ -354,7 +354,7 @@
 //!
 //! fn init_server(
 //!     storage_path: &Path,
-//!     mut hotshot: HotShotHandle<AppTypes, AppNodeImpl>,
+//!     mut hotshot: SystemContextHandle<AppTypes, AppNodeImpl>,
 //! ) -> Result<App<Arc<RwLock<AppState>>, Error>, Error> {
 //!     let mut loader = AtomicStoreLoader::create(storage_path, "my_app") // or `open`
 //!         .map_err(Error::internal)?;
@@ -405,7 +405,7 @@ pub use resolvable::Resolvable;
 
 use data_source::QueryData;
 use futures::Future;
-use hotshot::{certificate, types::HotShotHandle};
+use hotshot::{certificate, types::SystemContextHandle};
 use hotshot_types::{
     data::LeafType,
     traits::{
@@ -437,7 +437,7 @@ pub struct Options {
 pub fn run_standalone_service<Types: NodeType, I: NodeImplementation<Types>>(
     _options: &Options,
     _data_source: QueryData<Types, I, ()>,
-    _hotshot: HotShotHandle<Types, I>,
+    _hotshot: SystemContextHandle<Types, I>,
 ) -> impl Future<Output = ()> + Send + Sync + 'static
 where
     Block<Types>: QueryableBlock,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,7 +375,7 @@
 //!     // Register API modules.
 //!
 //!     spawn(async move {
-//! 		let mut events = hotshot.get_event_stream(Default::default()).await.0;
+//!         let mut events = hotshot.get_event_stream(Default::default()).await.0;
 //!         while let Some(event) = events.next().await {
 //!             let mut state = state.write().await;
 //!             state.hotshot_qs.update(&event).unwrap();

--- a/src/status.rs
+++ b/src/status.rs
@@ -117,7 +117,7 @@ mod test {
         setup_test();
 
         // Create the consensus network.
-        let network = MockNetwork::init(()).await;
+        let mut network = MockNetwork::init(()).await;
         let hotshot = network.handle();
 
         // Start the web server.

--- a/src/update.rs
+++ b/src/update.rs
@@ -33,7 +33,7 @@ use std::iter::once;
 /// If a type implements both [UpdateAvailabilityData] and [UpdateStatusData], then it can be fully
 /// kept up to date through two interfaces:
 /// * [metrics](UpdateDataSource::metrics), to get a handle for populating the status metrics, which
-///   should be used when initializing a [HotShotHandle](hotshot::types::HotShotHandle)
+///   should be used when initializing a [SystemContextHandle](hotshot::types::SystemContextHandle)
 /// * [update](UpdateDataSource::update), to update the query state when a new HotShot event is
 ///   emitted
 pub trait UpdateDataSource<Types: NodeType, I: NodeImplementation<Types>> {
@@ -42,8 +42,8 @@ pub trait UpdateDataSource<Types: NodeType, I: NodeImplementation<Types>> {
     /// Get a handle for populating status metrics.
     ///
     /// This function should be called before creating a
-    /// [HotShotHandle](hotshot::types::HotShotHandle), and the resulting [Metrics] handle should be
-    /// passed to HotShot, which will update it.
+    /// [SystemContextHandle](hotshot::types::SystemContextHandle), and the resulting [Metrics]
+    /// handle should be passed to HotShot, which will update it.
     fn metrics(&self) -> Box<dyn Metrics>;
 
     /// Update query state based on a new consensus event.
@@ -82,7 +82,7 @@ where
         Deltas<Types, I>: Resolvable<Block<Types>>,
         Block<Types>: QueryableBlock,
     {
-        if let EventType::Decide { leaf_chain, qc } = &event.event {
+        if let EventType::Decide { leaf_chain, qc, .. } = &event.event {
             // `qc` justifies the first (most recent) leaf...
             let qcs = once((**qc).clone())
                 // ...and each leaf in the chain justifies the subsequent leaf (its parent) through


### PR DESCRIPTION
This is a big change as it not only updates to async HotShot from the run_view_refactor branch, it is also the first time we have run the query service tests with sequencing consensus.

Actually, most of the non-trivial changes stem from the latter. In particular, the indexes by block hash and transaction hash have been updated to only return the earliest instance in case of duplicates. With validating consensus, we never had duplicates. The mock types and network for testing have also been reworked significantly.