### PR TITLE
Feat/generalize data source trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -526,7 +526,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1287,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "color-eyre"
@@ -1856,10 +1856,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -2675,7 +2676,7 @@ dependencies = [
  "serde",
  "snafu",
  "surf-disco",
- "time 0.3.28",
+ "time 0.3.30",
  "tokio",
  "tracing",
  "typenum",
@@ -2765,7 +2766,7 @@ dependencies = [
  "surf-disco",
  "tempdir",
  "tide-disco 0.4.1 (git+https://github.com/EspressoSystems/tide-disco.git?tag=v0.4.2)",
- "time 0.3.28",
+ "time 0.3.30",
  "toml 0.7.8",
  "tracing",
 ]
@@ -2836,7 +2837,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "snafu",
- "time 0.3.28",
+ "time 0.3.30",
  "tokio",
  "tracing",
 ]
@@ -2879,7 +2880,7 @@ dependencies = [
  "serde",
  "snafu",
  "tagged-base64 0.2.4",
- "time 0.3.28",
+ "time 0.3.30",
  "tokio",
  "tracing",
  "typenum",
@@ -4944,6 +4945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5331,7 +5338,7 @@ checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
 dependencies = [
  "pem",
  "ring",
- "time 0.3.28",
+ "time 0.3.30",
  "yasna",
 ]
 
@@ -5561,9 +5568,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
  "bitflags",
  "errno",
@@ -5681,18 +5688,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5764,7 +5771,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros 2.3.3",
- "time 0.3.28",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -5781,7 +5788,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros 3.3.0",
- "time 0.3.28",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -6662,22 +6669,23 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa 1.0.9",
+ "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.14",
+ "time-macros 0.2.15",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
@@ -6691,9 +6699,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -7593,7 +7601,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.28",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -7626,7 +7634,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
- "time 0.3.28",
+ "time 0.3.30",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,7 @@ version = "0.0.7"
 dependencies = [
  "async-compatibility-layer",
  "async-std",
+ "async-trait",
  "atomic_store",
  "backtrace-on-stack-overflow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,7 @@ dependencies = [
  "clap",
  "commit",
  "custom_debug",
+ "derivative",
  "derive_more",
  "either",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
     "logging-utils",
 ] }
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
+async-trait = "0.1"
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.3" }
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ async-compatibility-layer = { git = "https://github.com/EspressoSystems/async-co
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.3" }
 bincode = "1.3"
-clap = { version = "4.3", features = ["derive", "env"] }
+clap = { version = "4.4", features = ["derive", "env"] }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.2.2" }
 custom_debug = "0.5"
 derive_more = "0.99"
@@ -44,7 +44,7 @@ serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 spin_sleep = "1.1"
 tide-disco = { git = "https://github.com/EspressoSystems/tide-disco.git", tag = "v0.4.2" }
-time = "0.3.25"
+time = "0.3"
 toml = "0.7"
 tracing = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "env"] }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.2.2" }
 custom_debug = "0.5"
+derivative = "2.2"
 derive_more = "0.99"
 either = "1.8"
 futures = "0.3"

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -14,9 +14,12 @@ use crate::{api::load_api, Block};
 use clap::Args;
 use derive_more::From;
 use futures::{FutureExt, StreamExt, TryFutureExt};
-use hotshot_types::traits::node_implementation::{NodeImplementation, NodeType};
+use hotshot_types::traits::{
+    node_implementation::{NodeImplementation, NodeType},
+    signature_key::EncodedPublicKey,
+};
 use serde::{Deserialize, Serialize};
-use snafu::{OptionExt, Snafu};
+use snafu::{OptionExt, ResultExt, Snafu};
 use std::fmt::Display;
 use std::path::PathBuf;
 use tide_disco::{api::ApiError, method::ReadState, Api, RequestError, StatusCode};
@@ -44,70 +47,36 @@ pub struct Options {
 }
 
 #[derive(Clone, Debug, From, Snafu, Deserialize, Serialize)]
+#[snafu(visibility(pub))]
 pub enum Error {
     Request {
         source: RequestError,
     },
-    /// The requested leaf hash is not in the database.
-    #[snafu(display("the requested leaf hash {} is not in the database", hash))]
+    #[snafu(display("error fetching leaf {resource}: {source}"))]
     #[from(ignore)]
-    UnknownLeafHash {
-        hash: String,
+    QueryLeaf {
+        source: QueryError,
+        resource: String,
     },
-    /// The requested leaf height is out of range for the current ledger.
-    #[snafu(display(
-        "the requested leaf height {} is out of range for the current ledger",
-        height
-    ))]
+    #[snafu(display("error fetching block {resource}: {source}"))]
     #[from(ignore)]
-    InvalidLeafHeight {
-        height: u64,
+    QueryBlock {
+        source: QueryError,
+        resource: String,
     },
-    /// The requested leaf exists but this query service instance does not have its data.
-    #[snafu(display(
-        "the requested leaf {} exists but this query service instance does not have its data",
-        height
-    ))]
+    #[snafu(display("error fetching transaction {resource}: {source}"))]
     #[from(ignore)]
-    MissingLeaf {
-        height: u64,
+    QueryTransaction {
+        source: QueryError,
+        resource: String,
     },
-    /// The requested block hash is not in the database.
-    #[snafu(display("the requested block hash {} is not in the database", hash))]
+    #[snafu(display("error fetching proposals by {proposer}: {source}"))]
     #[from(ignore)]
-    UnknownBlockHash {
-        hash: String,
+    QueryProposals {
+        source: QueryError,
+        proposer: EncodedPublicKey,
     },
-    /// The requested block height is out of range for the current ledger.
-    #[snafu(display(
-        "the requested block height {} is out of range for the current ledger",
-        height
-    ))]
-    #[from(ignore)]
-    InvalidBlockHeight {
-        height: u64,
-    },
-    /// The requested block exists but this query service instance does not have its data.
-    #[snafu(display(
-        "the requested block {} exists but this query service instance does not have its data",
-        height
-    ))]
-    #[from(ignore)]
-    MissingBlock {
-        height: u64,
-    },
-    /// The requested transaction hash is not in the database.
-    #[snafu(display("the requested transaction hash {} is not in the database", hash))]
-    #[from(ignore)]
-    UnknownTransactionHash {
-        hash: String,
-    },
-    /// The requested transaction index is out of range for its block.
-    #[snafu(display(
-        "the requested transaction index {} is out of range for its block {}",
-        index,
-        height
-    ))]
+    #[snafu(display("transaction index {index} out of range for block {height}"))]
     #[from(ignore)]
     InvalidTransactionIndex {
         height: u64,
@@ -142,14 +111,14 @@ impl Error {
     pub fn status(&self) -> StatusCode {
         match self {
             Self::Request { .. } => StatusCode::BadRequest,
-            Self::UnknownLeafHash { .. }
-            | Self::InvalidLeafHeight { .. }
-            | Self::MissingLeaf { .. }
-            | Self::UnknownBlockHash { .. }
-            | Self::InvalidBlockHeight { .. }
-            | Self::MissingBlock { .. }
-            | Self::UnknownTransactionHash { .. }
-            | Self::InvalidTransactionIndex { .. } => StatusCode::NotFound,
+            Self::QueryLeaf { source, .. }
+            | Self::QueryBlock { source, .. }
+            | Self::QueryTransaction { source, .. }
+            | Self::QueryProposals { source, .. } => match source {
+                QueryError::NotFound | QueryError::Missing => StatusCode::NotFound,
+                QueryError::Error { .. } => StatusCode::InternalServerError,
+            },
+            Self::InvalidTransactionIndex { .. } => StatusCode::NotFound,
             Self::LeafStream { .. } | Self::BlockStream { .. } => StatusCode::InternalServerError,
             Self::Custom { status, .. } => *status,
         }
@@ -172,22 +141,13 @@ where
     api.with_version("0.0.1".parse().unwrap())
         .get("getleaf", |req, state| {
             async move {
-                let height = match req.opt_integer_param("height")? {
-                    Some(height) => height,
-                    None => {
-                        let hash = req.blob_param("hash")?;
-                        state
-                            .get_leaf_index_by_hash(hash)
-                            .context(UnknownLeafHashSnafu {
-                                hash: hash.to_string(),
-                            })?
-                    }
+                let id = match req.opt_integer_param("height")? {
+                    Some(height) => ResourceId::Number(height),
+                    None => ResourceId::Hash(req.blob_param("hash")?),
                 };
-                state
-                    .get_nth_leaf_iter(height as usize)
-                    .next()
-                    .context(InvalidLeafHeightSnafu { height })?
-                    .context(MissingLeafSnafu { height })
+                state.get_leaf(id).context(QueryLeafSnafu {
+                    resource: id.to_string(),
+                })
             }
             .boxed()
         })?
@@ -235,18 +195,13 @@ where
         })?
         .get("getblock", |req, state| {
             async move {
-                let height = match req.opt_integer_param("height")? {
-                    Some(height) => height,
-                    None => {
-                        let hash = req.blob_param("hash")?;
-                        state
-                            .get_block_index_by_hash(hash)
-                            .context(UnknownBlockHashSnafu {
-                                hash: hash.to_string(),
-                            })?
-                    }
+                let id = match req.opt_integer_param("height")? {
+                    Some(height) => ResourceId::Number(height),
+                    None => ResourceId::Hash(req.blob_param("hash")?),
                 };
-                get_block(state, height)
+                state.get_block(id).context(QueryBlockSnafu {
+                    resource: id.to_string(),
+                })
             }
             .boxed()
         })?
@@ -275,20 +230,21 @@ where
             async move {
                 let (block, index) = match req.opt_blob_param("hash")? {
                     Some(hash) => {
-                        let (height, index) = state.get_txn_index_by_hash(hash).context(
-                            UnknownTransactionHashSnafu {
-                                hash: hash.to_string(),
-                            },
-                        )?;
-                        let block = get_block(state, height)?;
-                        (block, index)
+                        state
+                            .get_block_with_transaction(hash)
+                            .context(QueryTransactionSnafu {
+                                resource: hash.to_string(),
+                            })?
                     }
                     None => {
                         let height = req.integer_param("height")?;
-                        let block = get_block(state, height)?;
+                        let id = ResourceId::Number(height);
+                        let block = state.get_block(id).context(QueryBlockSnafu {
+                            resource: id.to_string(),
+                        })?;
                         let i = req.integer_param("index")?;
                         let index = block.block().nth(i).context(InvalidTransactionIndexSnafu {
-                            height,
+                            height: height as u64,
                             index: i as u64,
                         })?;
                         (block, index)
@@ -304,47 +260,23 @@ where
         .get("countproposals", |req, state| {
             async move {
                 let proposer = req.blob_param("proposer_id")?;
-                Ok(state.get_block_ids_by_proposer_id(&proposer).len())
+                state
+                    .count_proposals(&proposer)
+                    .context(QueryProposalsSnafu { proposer })
             }
             .boxed()
         })?
         .get("getproposals", |req, state| {
             async move {
                 let proposer = req.blob_param("proposer_id")?;
-                let all_ids = state.get_block_ids_by_proposer_id(&proposer);
-                let start_from = match req.opt_integer_param("count")? {
-                    Some(count) => all_ids.len().saturating_sub(count),
-                    None => 0,
-                };
-                all_ids
-                    .into_iter()
-                    .skip(start_from)
-                    .map(|height| {
-                        state
-                            .get_nth_leaf_iter(height as usize)
-                            .next()
-                            .context(InvalidLeafHeightSnafu { height })?
-                            .context(MissingLeafSnafu { height })
-                    })
-                    .collect::<Result<Vec<_>, _>>()
+                let limit = req.opt_integer_param("count")?;
+                state
+                    .get_proposals(&proposer, limit)
+                    .context(QueryProposalsSnafu { proposer })
             }
             .boxed()
         })?;
     Ok(api)
-}
-
-fn get_block<State, Types, I>(state: &State, height: u64) -> Result<BlockQueryData<Types>, Error>
-where
-    State: AvailabilityDataSource<Types, I>,
-    Block<Types>: QueryableBlock,
-    Types: NodeType,
-    I: NodeImplementation<Types>,
-{
-    state
-        .get_nth_block_iter(height as usize)
-        .next()
-        .context(InvalidBlockHeightSnafu { height })?
-        .context(MissingBlockSnafu { height })
 }
 
 #[cfg(test)]
@@ -396,12 +328,14 @@ mod test {
                     }
                 }
                 Err(Error::Availability {
-                    source: super::Error::InvalidBlockHeight { height },
-                }) if height == i => {
+                    source:
+                        super::Error::QueryBlock {
+                            source: QueryError::NotFound,
+                            ..
+                        },
+                }) => {
                     tracing::info!(
-                        "found end of ledger at height {}, non-empty blocks are {:?}",
-                        i,
-                        blocks
+                        "found end of ledger at height {i}, non-empty blocks are {blocks:?}",
                     );
                     return (i, blocks);
                 }

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -50,7 +50,15 @@ pub trait QueryableBlock: traits::Block {
     /// internally however they want (e.g. by position or by hash). Meanwhile, many high-level
     /// functions for querying transactions by different means can be implemented by returning a
     /// `TransactionIndex` and then finally using it to retrieve the desired transaction.
-    type TransactionIndex: Clone + Debug + PartialEq + Eq + Ord + Serialize + DeserializeOwned;
+    type TransactionIndex: Clone
+        + Debug
+        + PartialEq
+        + Eq
+        + Ord
+        + Serialize
+        + DeserializeOwned
+        + Send
+        + Sync;
 
     /// Enumerate the transactions in this block.
     type Iter<'a>: Iterator<Item = Self::TransactionIndex>

--- a/src/status.rs
+++ b/src/status.rs
@@ -75,16 +75,16 @@ where
     )?;
     api.with_version("0.0.1".parse().unwrap())
         .get("latest_block_height", |_, state| {
-            async { state.block_height().map_err(internal) }.boxed()
+            async { state.block_height().await.map_err(internal) }.boxed()
         })?
         .get("mempool_info", |_, state| {
-            async { state.mempool_info().map_err(internal) }.boxed()
+            async { state.mempool_info().await.map_err(internal) }.boxed()
         })?
         .get("success_rate", |_, state| {
-            async { state.success_rate().map_err(internal) }.boxed()
+            async { state.success_rate().await.map_err(internal) }.boxed()
         })?
         .get("metrics", |_, state| {
-            async { state.export_metrics().map_err(internal) }.boxed()
+            async { state.export_metrics().await.map_err(internal) }.boxed()
         })?;
     Ok(api)
 }

--- a/src/status/data_source.rs
+++ b/src/status/data_source.rs
@@ -11,18 +11,20 @@
 // see <https://www.gnu.org/licenses/>.
 
 use super::query_data::MempoolQueryData;
+use async_trait::async_trait;
 use hotshot_types::traits::metrics::Metrics;
 use std::error::Error;
 use std::fmt::Debug;
 
+#[async_trait]
 pub trait StatusDataSource {
     type Error: Error + Debug;
-    fn block_height(&self) -> Result<usize, Self::Error>;
-    fn mempool_info(&self) -> Result<MempoolQueryData, Self::Error>;
-    fn success_rate(&self) -> Result<f64, Self::Error>;
+    async fn block_height(&self) -> Result<usize, Self::Error>;
+    async fn mempool_info(&self) -> Result<MempoolQueryData, Self::Error>;
+    async fn success_rate(&self) -> Result<f64, Self::Error>;
 
     /// Export all available metrics in the Prometheus text format.
-    fn export_metrics(&self) -> Result<String, Self::Error>;
+    async fn export_metrics(&self) -> Result<String, Self::Error>;
 }
 
 pub trait UpdateStatusData {

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -177,7 +177,7 @@ impl<UserData: Send + Sync + 'static> MockNetwork<UserData> {
                 while let Some(event) = events.next().await {
                     tracing::info!("EVENT {:?}", event.event);
                     let mut qd = qd.write().await;
-                    qd.update(&event).unwrap();
+                    qd.update(&event).await.unwrap();
                     qd.commit_version().await.unwrap();
                 }
             });


### PR DESCRIPTION
Adapt the data source traits to be more amenable to the new SQL implementation:
* Make the trait operations higher level, so that the API layer can request a complex operation and the SQL backend can accomplish it in a single query, instead of breaking the operation down into multiple intermediate queries
* Make the trait functions async, so we can avoid blocking executor threads on I/O. This will be especially important when we add the network latency of a round-trip to a remote SQL database.

Closes #242 