### PR TITLE
Add a feature to reset the SQL database; streamline and extend the public query API

### DIFF
--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -375,6 +375,8 @@ pub mod availability_tests {
         assert_eq!(leaf, ds.get_leaf(1).await.unwrap());
         assert_eq!(block, ds.get_block(1).await.unwrap());
 
+        drop(ds);
+
         // Reset and check that the changes are gone.
         let ds = D::reset(&storage).await;
         assert_eq!(ds.block_height().await.unwrap(), 1);

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -248,6 +248,10 @@ mod impl_testable_data_source {
             Self::new(D::connect(storage).await, Default::default())
         }
 
+        async fn reset(storage: &Self::Storage) -> Self {
+            Self::new(D::reset(storage).await, Default::default())
+        }
+
         async fn handle_event(&mut self, event: &Event<MockTypes>) {
             self.update(event).await.unwrap();
             self.commit().await.unwrap();

--- a/src/data_source/fs.rs
+++ b/src/data_source/fs.rs
@@ -606,6 +606,10 @@ mod impl_testable_data_source {
             Self::open(storage.path()).await.unwrap()
         }
 
+        async fn reset(storage: &Self::Storage) -> Self {
+            Self::create(storage.path()).await.unwrap()
+        }
+
         async fn handle_event(&mut self, event: &Event<MockTypes>) {
             self.update(event).await.unwrap();
             self.commit().await.unwrap();

--- a/src/data_source/metrics.rs
+++ b/src/data_source/metrics.rs
@@ -103,6 +103,12 @@ mod impl_testable_data_source {
             }
         }
 
+        async fn reset(storage: &Self::Storage) -> Self {
+            Self {
+                metrics: storage.clone(),
+            }
+        }
+
         async fn handle_event(&mut self, _event: &Event<MockTypes>) {}
     }
 }

--- a/src/data_source/sql.rs
+++ b/src/data_source/sql.rs
@@ -336,7 +336,7 @@ impl Config {
 ///
 /// ## Resetting
 ///
-/// In general, resetting the database when necessary is left up to the adminstrator. However, for
+/// In general, resetting the database when necessary is left up to the administrator. However, for
 /// convenience, we do provide a [`reset_schema`](Config::reset_schema) option which can be used to
 /// wipe out existing state and create a fresh instance of the query service. This is particularly
 /// useful for development and staging environments. This function will permanently delete all

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -115,6 +115,7 @@ pub trait DataSourceLifeCycle: Send + Sync + Sized + 'static {
 
     async fn create(node_id: usize) -> Self::Storage;
     async fn connect(storage: &Self::Storage) -> Self;
+    async fn reset(storage: &Self::Storage) -> Self;
     async fn handle_event(&mut self, event: &Event<MockTypes>);
 }
 


### PR DESCRIPTION
This probably should have been two separate PRs, sorry about that. Got a little carried away. If you look at the diff for each commit separately, hopefully it is pretty straightforward.