### PR TITLE
chore: update hotshot to 0.5.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 [[package]]
 name = "commit"
 version = "0.2.2"
-source = "git+https://github.com/EspressoSystems/commit.git#fa1d0cb00bda1cc06c239aaf3a692014489d88c8"
+source = "git+https://github.com/EspressoSystems/commit.git#dd9f16e084d45e9ea52459c776f5fdcb6b000889"
 dependencies = [
  "arbitrary",
  "ark-serialize 0.4.2",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2784,12 +2784,15 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2800,6 +2803,7 @@ dependencies = [
  "hotshot-types",
  "libp2p",
  "serde",
+ "serde-inline-default",
  "serde_json",
  "surf-disco",
  "thiserror",
@@ -2858,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2877,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2902,14 +2906,19 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
+ "async-lock 2.8.0",
  "async-std",
+ "bincode",
+ "bitvec",
  "commit",
  "either",
+ "ethereum-types",
  "futures",
  "hotshot",
+ "hotshot-constants",
  "hotshot-orchestrator",
  "hotshot-task",
  "hotshot-task-impls",
@@ -2926,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "ark-bls12-381",
  "ark-ed-on-bn254",
@@ -2950,6 +2959,7 @@ dependencies = [
  "espresso-systems-common 0.4.1",
  "ethereum-types",
  "generic-array",
+ "hotshot-constants",
  "hotshot-task",
  "hotshot-utils",
  "jf-plonk",
@@ -2971,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "bincode",
 ]
@@ -2979,7 +2989,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3432,7 +3442,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#33f963714707a9b11c407a0e60c63799f983f788"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3461,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#33f963714707a9b11c407a0e60c63799f983f788"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3506,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#33f963714707a9b11c407a0e60c63799f983f788"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3532,7 +3542,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish#33f963714707a9b11c407a0e60c63799f983f788"
+source = "git+https://github.com/EspressoSystems/jellyfish#bf1a6dfb63e2ce9b409a682d2793b836f1659097"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3923,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7#18a528c672ebb65ea611f136a1fafcd200401931"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.7.1#62fbfde8613e99478ef530f37a202fe6d890ad90"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -6095,6 +6105,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-inline-default"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa824cde50b5f01ff28a955114d8152a07cd62d81f53459dad0f2610136be844"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes 1.5.0",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.8"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1" }
 itertools = "0.12"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
@@ -87,7 +87,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7", optional = true }
+hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -107,7 +107,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 # Adding since it was showing some warnings in the `testing/mocks.rs`
-hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.7.1" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"


### PR DESCRIPTION
we need this for light client integration: https://github.com/EspressoSystems/HotShot/pull/2439