### PR TITLE
Chaos testing: Implement a query storage that relies purely on peer data

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,9 @@ jobs:
           - sql-data-source
           - file-system-data-source
           - metrics-data-source
+          - no-storage
           # All optional features together
-          - sql-data-source,file-system-data-source,metrics-data-source
+          - sql-data-source,file-system-data-source,metrics-data-source,no-storage
     env:
         RUSTFLAGS: "--cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\""
         RUST_LOG: info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cld"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021080b0a3dbefcf1c1f0b3ad6a923b81f16801d874ec338c168ac0b0762baf5"
+
+[[package]]
 name = "color-eyre"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2831,7 @@ dependencies = [
  "backtrace-on-stack-overflow",
  "bincode",
  "clap",
+ "cld",
  "commit",
  "custom_debug",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 async-trait = "0.1"
 bincode = "1.3"
 clap = { version = "4.4", features = ["derive", "env"] }
+cld = "0.5"
 commit = { git = "https://github.com/EspressoSystems/commit.git" }
 custom_debug = "0.5"
 derivative = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,21 @@ license = "GPL-3.0-or-later"
 
 [features]
 default = ["file-system-data-source", "metrics-data-source", "sql-data-source"]
+
+# Enable the availability data source backed by the local file system.
 file-system-data-source = ["atomic_store"]
+
+# Enable a lightweight data source for status APIs without the archival availability API.
 metrics-data-source = []
+
+# Enable a mock persistence layer which doesn't actually persist anything.
+#
+# This is useful for adversarial testing, as it can be used to test the behavior of the query
+# service where data is never available locally and must always be fetched on demand from a peer
+# query service.
+no-storage = []
+
+# Enable the availability data source backed by a Postgres database.
 sql-data-source = [
 	"include_dir",
 	"native-tls",
@@ -30,6 +43,8 @@ sql-data-source = [
 	"tokio",
 	"tokio-postgres",
 ]
+
+# Enable extra features useful for writing tests with a query service.
 testing = [
 	"espresso-macros",
 	"hotshot-testing",

--- a/examples/simple-server.rs
+++ b/examples/simple-server.rs
@@ -32,7 +32,10 @@ use hotshot_query_service::{
     fetching::provider::NoFetching,
     run_standalone_service,
     status::UpdateStatusData,
-    testing::mocks::{DataSourceLifeCycle, MockMembership, MockNodeImpl, MockTypes},
+    testing::{
+        consensus::DataSourceLifeCycle,
+        mocks::{MockMembership, MockNodeImpl, MockTypes},
+    },
     Error,
 };
 use hotshot_types::{

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -55,8 +55,8 @@ pub mod availability_tests {
         },
         node::NodeDataSource,
         testing::{
-            consensus::MockNetwork,
-            mocks::{mock_transaction, MockPayload, MockTypes, TestableDataSource},
+            consensus::{MockNetwork, TestableDataSource},
+            mocks::{mock_transaction, MockPayload, MockTypes},
             setup_test,
         },
         Leaf,
@@ -460,8 +460,8 @@ pub mod status_tests {
     use crate::{
         status::{MempoolQueryData, StatusDataSource},
         testing::{
-            consensus::MockNetwork,
-            mocks::{mock_transaction, DataSourceLifeCycle},
+            consensus::{DataSourceLifeCycle, MockNetwork},
+            mocks::mock_transaction,
             setup_test, sleep,
         },
     };

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -260,7 +260,10 @@ mod impl_testable_data_source {
     use super::*;
     use crate::{
         data_source::UpdateDataSource,
-        testing::mocks::{DataSourceLifeCycle, MockTypes, TestableDataSource},
+        testing::{
+            consensus::{DataSourceLifeCycle, TestableDataSource},
+            mocks::MockTypes,
+        },
     };
     use hotshot::types::Event;
 

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -296,7 +296,6 @@ mod impl_testable_data_source {
 
 #[cfg(test)]
 mod test {
-    use super::super::{availability_tests, status_tests};
     use super::ExtensibleDataSource;
     use crate::testing::consensus::MockDataSource;
 

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -262,8 +262,7 @@ where
         Builder::new(storage, provider)
     }
 
-    /// Create a data source with local storage and a remote data availability provider.
-    pub async fn new(builder: Builder<Types, S, P>) -> anyhow::Result<Self> {
+    async fn new(builder: Builder<Types, S, P>) -> anyhow::Result<Self> {
         let proactive_fetching = builder.proactive_fetching;
         let minor_interval = builder.minor_scan_interval;
         let major_interval = builder.major_scan_interval;

--- a/src/data_source/fs.rs
+++ b/src/data_source/fs.rs
@@ -221,7 +221,7 @@ mod impl_testable_data_source {
     use super::*;
     use crate::{
         data_source::{UpdateDataSource, VersionedDataSource},
-        testing::mocks::{DataSourceLifeCycle, MockTypes},
+        testing::{consensus::DataSourceLifeCycle, mocks::MockTypes},
     };
     use async_trait::async_trait;
     use hotshot::types::Event;

--- a/src/data_source/fs.rs
+++ b/src/data_source/fs.rs
@@ -12,7 +12,7 @@
 
 #![cfg(feature = "file-system-data-source")]
 
-use super::{storage::FileSystemStorage, FetchingDataSource};
+use super::{storage::FileSystemStorage, AvailabilityProvider, FetchingDataSource};
 use crate::{availability::query_data::QueryablePayload, Payload};
 use atomic_store::AtomicStoreLoader;
 use hotshot_types::traits::node_implementation::NodeType;
@@ -146,7 +146,7 @@ pub type FileSystemDataSource<Types, P> = FetchingDataSource<Types, FileSystemSt
 impl<Types: NodeType, P> FileSystemDataSource<Types, P>
 where
     Payload<Types>: QueryablePayload,
-    P: Send + Sync,
+    P: AvailabilityProvider<Types>,
 {
     /// Create a new [FileSystemDataSource] with storage at `path`.
     ///
@@ -154,7 +154,9 @@ where
     ///
     /// The [FileSystemDataSource] will manage its own persistence synchronization.
     pub async fn create(path: &Path, provider: P) -> anyhow::Result<Self> {
-        FetchingDataSource::new(FileSystemStorage::create(path).await?, provider).await
+        FetchingDataSource::builder(FileSystemStorage::create(path).await?, provider)
+            .build()
+            .await
     }
 
     /// Open an existing [FileSystemDataSource] from storage at `path`.
@@ -163,7 +165,9 @@ where
     ///
     /// The [FileSystemDataSource] will manage its own persistence synchronization.
     pub async fn open(path: &Path, provider: P) -> anyhow::Result<Self> {
-        FetchingDataSource::new(FileSystemStorage::open(path).await?, provider).await
+        FetchingDataSource::builder(FileSystemStorage::open(path).await?, provider)
+            .build()
+            .await
     }
 
     /// Create a new [FileSystemDataSource] using a persistent storage loader.
@@ -178,10 +182,11 @@ where
         loader: &mut AtomicStoreLoader,
         provider: P,
     ) -> anyhow::Result<Self> {
-        FetchingDataSource::new(
+        FetchingDataSource::builder(
             FileSystemStorage::create_with_store(loader).await?,
             provider,
         )
+        .build()
         .await
     }
 
@@ -197,7 +202,9 @@ where
         loader: &mut AtomicStoreLoader,
         provider: P,
     ) -> anyhow::Result<Self> {
-        FetchingDataSource::new(FileSystemStorage::open_with_store(loader).await?, provider).await
+        FetchingDataSource::builder(FileSystemStorage::open_with_store(loader).await?, provider)
+            .build()
+            .await
     }
 
     /// Advance the version of the persistent store without committing changes to persistent state.
@@ -228,7 +235,7 @@ mod impl_testable_data_source {
     use tempdir::TempDir;
 
     #[async_trait]
-    impl<P: Default + Send + Sync + 'static> DataSourceLifeCycle
+    impl<P: AvailabilityProvider<MockTypes> + Default> DataSourceLifeCycle
         for FileSystemDataSource<MockTypes, P>
     {
         type Storage = TempDir;
@@ -258,7 +265,6 @@ mod impl_testable_data_source {
 
 #[cfg(test)]
 mod test {
-    use super::super::{availability_tests, status_tests};
     use super::FileSystemDataSource;
     use crate::{fetching::provider::NoFetching, testing::mocks::MockTypes};
 

--- a/src/data_source/metrics.rs
+++ b/src/data_source/metrics.rs
@@ -86,7 +86,7 @@ impl StatusDataSource for MetricsDataSource {
 #[cfg(any(test, feature = "testing"))]
 mod impl_testable_data_source {
     use super::*;
-    use crate::testing::mocks::{DataSourceLifeCycle, MockTypes};
+    use crate::testing::{consensus::DataSourceLifeCycle, mocks::MockTypes};
     use hotshot::types::Event;
 
     #[async_trait]

--- a/src/data_source/sql.rs
+++ b/src/data_source/sql.rs
@@ -13,8 +13,9 @@
 #![cfg(feature = "sql-data-source")]
 
 use super::{
+    fetching,
     storage::sql::{self, SqlStorage},
-    FetchingDataSource,
+    AvailabilityProvider, FetchingDataSource,
 };
 use crate::{availability::QueryablePayload, Payload, QueryResult};
 use async_std::sync::Arc;
@@ -30,12 +31,27 @@ pub use tokio_postgres as postgres;
 
 pub use sql::{Config, Query, Transaction};
 
+pub type Builder<Types, Provider> = fetching::Builder<Types, SqlStorage, Provider>;
+
 impl Config {
     /// Connect to the database with this config.
-    pub async fn connect<Types, P: Send + Sync>(
+    pub async fn connect<Types, P: AvailabilityProvider<Types>>(
         self,
         provider: P,
     ) -> Result<SqlDataSource<Types, P>, Error>
+    where
+        Types: NodeType,
+        Payload<Types>: QueryablePayload,
+    {
+        self.builder(provider).await?.build().await
+    }
+
+    /// Connect to the database, setting options on the underlying [`FetchingDataSource`] using the
+    /// [`fetching::Builder`] interface.
+    pub async fn builder<Types, P: AvailabilityProvider<Types>>(
+        self,
+        provider: P,
+    ) -> Result<Builder<Types, P>, Error>
     where
         Types: NodeType,
         Payload<Types>: QueryablePayload,
@@ -287,14 +303,19 @@ impl Config {
 /// ```
 pub type SqlDataSource<Types, P> = FetchingDataSource<Types, SqlStorage, P>;
 
-impl<Types, P: Send + Sync> SqlDataSource<Types, P>
+impl<Types, P: AvailabilityProvider<Types>> SqlDataSource<Types, P>
 where
     Types: NodeType,
     Payload<Types>: QueryablePayload,
 {
     /// Connect to a remote database.
-    pub async fn connect(config: Config, provider: P) -> Result<Self, Error> {
-        Self::new(SqlStorage::connect(config).await?, provider).await
+    ///
+    /// This function returns a [`fetching::Builder`] which can be used to set options on the
+    /// underlying [`FetchingDataSource`], before constructing the [`SqlDataSource`] with
+    /// [`build`](fetching::Builder::build). For a convenient constructor that uses the default
+    /// fetching options, see [`Config::connect`].
+    pub async fn connect(config: Config, provider: P) -> Result<Builder<Types, P>, Error> {
+        Ok(Self::builder(SqlStorage::connect(config).await?, provider))
     }
 }
 
@@ -343,7 +364,9 @@ pub mod testing {
     pub use sql::testing::TmpDb;
 
     #[async_trait]
-    impl<P: Default + Send + Sync + 'static> DataSourceLifeCycle for SqlDataSource<MockTypes, P> {
+    impl<P: AvailabilityProvider<MockTypes> + Default> DataSourceLifeCycle
+        for SqlDataSource<MockTypes, P>
+    {
         type Storage = TmpDb;
 
         async fn create(_node_id: usize) -> Self::Storage {
@@ -373,7 +396,6 @@ pub mod testing {
 // These tests run the `postgres` Docker image, which doesn't work on Windows.
 #[cfg(all(test, not(target_os = "windows")))]
 mod generic_test {
-    use super::super::{availability_tests, status_tests};
     use super::SqlDataSource;
     use crate::{fetching::provider::NoFetching, testing::mocks::MockTypes};
 

--- a/src/data_source/sql.rs
+++ b/src/data_source/sql.rs
@@ -336,7 +336,7 @@ pub mod testing {
     use super::*;
     use crate::{
         data_source::{UpdateDataSource, VersionedDataSource},
-        testing::mocks::{DataSourceLifeCycle, MockTypes},
+        testing::{consensus::DataSourceLifeCycle, mocks::MockTypes},
     };
     use hotshot::types::Event;
 

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -21,6 +21,7 @@
 //! This module also comes with a few pre-built persistence implementations:
 //! * [`SqlStorage`]
 //! * [`FileSystemStorage`]
+//! * [`NoStorage`]
 //!
 
 use crate::{
@@ -37,10 +38,13 @@ use std::ops::RangeBounds;
 
 pub mod fs;
 mod ledger_log;
+pub mod no_storage;
 pub mod sql;
 
 #[cfg(feature = "file-system-data-source")]
 pub use fs::FileSystemStorage;
+#[cfg(feature = "no-storage")]
+pub use no_storage::NoStorage;
 #[cfg(feature = "sql-data-source")]
 pub use sql::SqlStorage;
 

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -1,0 +1,155 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the HotShot Query Service library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not,
+// see <https://www.gnu.org/licenses/>.
+
+#![cfg(feature = "no-storage")]
+
+use super::AvailabilityStorage;
+use crate::{
+    availability::{
+        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryablePayload,
+        TransactionHash, TransactionIndex, UpdateAvailabilityData,
+    },
+    data_source::VersionedDataSource,
+    node::{NodeDataSource, UpdateNodeData},
+    Header, Payload, QueryError, QueryResult, SignatureKey,
+};
+use async_trait::async_trait;
+use hotshot_types::traits::node_implementation::NodeType;
+use std::{convert::Infallible, ops::RangeBounds};
+
+/// Mock storage implementation which doesn't actually store anything.
+///
+/// This is useful for adversarial testing, as it can be used to test the behavior of the query
+/// service where data is never available locally and must always be fetched on demand from a peer
+/// query service.
+#[derive(Clone, Debug, Default, Copy)]
+pub struct NoStorage;
+
+#[async_trait]
+impl VersionedDataSource for NoStorage {
+    type Error = Infallible;
+
+    async fn commit(&mut self) -> Result<(), Infallible> {
+        Ok(())
+    }
+
+    async fn revert(&mut self) {}
+}
+
+#[async_trait]
+impl<Types: NodeType> AvailabilityStorage<Types> for NoStorage
+where
+    Payload<Types>: QueryablePayload,
+{
+    async fn get_leaf(&self, _id: LeafId<Types>) -> QueryResult<LeafQueryData<Types>> {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_block(&self, _id: BlockId<Types>) -> QueryResult<BlockQueryData<Types>> {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_header(&self, _id: BlockId<Types>) -> QueryResult<Header<Types>> {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_payload(&self, _id: BlockId<Types>) -> QueryResult<PayloadQueryData<Types>> {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_leaf_range<R>(
+        &self,
+        _range: R,
+    ) -> QueryResult<Vec<QueryResult<LeafQueryData<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_block_range<R>(
+        &self,
+        _range: R,
+    ) -> QueryResult<Vec<QueryResult<BlockQueryData<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_payload_range<R>(
+        &self,
+        _range: R,
+    ) -> QueryResult<Vec<QueryResult<PayloadQueryData<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_block_with_transaction(
+        &self,
+        _hash: TransactionHash<Types>,
+    ) -> QueryResult<(BlockQueryData<Types>, TransactionIndex<Types>)> {
+        Err(QueryError::Missing)
+    }
+}
+
+#[async_trait]
+impl<Types: NodeType> UpdateAvailabilityData<Types> for NoStorage
+where
+    Payload<Types>: QueryablePayload,
+{
+    type Error = Infallible;
+
+    async fn insert_leaf(&mut self, _leaf: LeafQueryData<Types>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    async fn insert_block(&mut self, _block: BlockQueryData<Types>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<Types: NodeType> NodeDataSource<Types> for NoStorage
+where
+    Payload<Types>: QueryablePayload,
+{
+    async fn block_height(&self) -> QueryResult<usize> {
+        Ok(0)
+    }
+
+    async fn get_proposals(
+        &self,
+        _id: &SignatureKey<Types>,
+        _limit: Option<usize>,
+    ) -> QueryResult<Vec<LeafQueryData<Types>>> {
+        Err(QueryError::Missing)
+    }
+
+    async fn count_proposals(&self, _id: &SignatureKey<Types>) -> QueryResult<usize> {
+        Err(QueryError::Missing)
+    }
+}
+
+#[async_trait]
+impl<Types: NodeType> UpdateNodeData<Types> for NoStorage
+where
+    Payload<Types>: QueryablePayload,
+{
+    type Error = Infallible;
+
+    async fn insert_leaf(&mut self, _leaf: LeafQueryData<Types>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,7 @@ pub mod metrics;
 pub mod node;
 mod resolvable;
 pub mod status;
+mod task;
 pub mod testing;
 
 pub use error::Error;

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the HotShot Query Service library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not,
+// see <https://www.gnu.org/licenses/>.
+
+//! Async task utilites.
+
+use async_std::{
+    sync::Arc,
+    task::{spawn, JoinHandle},
+};
+use futures::future::Future;
+use std::fmt::Display;
+
+#[derive(Debug)]
+struct BackgroundTaskInner {
+    name: String,
+    handle: JoinHandle<()>,
+}
+
+/// A background task which is cancelled on [`Drop`]
+///
+/// This handle can be cloned; cloning it does not clone the underlying task. There may be many
+/// handles to the same background task, and the task will be cancelled when all handles are
+/// dropped.
+#[derive(Clone, Debug)]
+pub struct BackgroundTask {
+    inner: Option<Arc<BackgroundTaskInner>>,
+}
+
+impl BackgroundTask {
+    /// Spawn a background task, which will be cancelled when every clone is dropped.
+    pub fn spawn<F>(name: impl Display, future: F) -> Self
+    where
+        F: Future + Send + 'static,
+    {
+        let name = name.to_string();
+        let handle = {
+            let name = name.clone();
+            spawn(async move {
+                tracing::info!("spawning background task {name}");
+                future.await;
+                tracing::info!("background task {name} completed");
+            })
+        };
+
+        Self {
+            inner: Some(Arc::new(BackgroundTaskInner { name, handle })),
+        }
+    }
+}
+
+impl Drop for BackgroundTask {
+    fn drop(&mut self) {
+        // `inner` should never be [`None`] here, we only `take` it because we are given `&mut
+        // self` (so that this can be called from [`drop`]) and thus we cannot move out of `self`.
+        // Nevertheless, it doesn't hurt to explicitly check for [`Some`].
+        if let Some(inner) = self.inner.take() {
+            // Check if this is the last instance of the [`Arc`] and, if so, cancel the underlying
+            // task.
+            if let Some(inner) = Arc::into_inner(inner) {
+                tracing::info!("cancelling background task {}", inner.name);
+                async_std::task::block_on(inner.handle.cancel());
+            }
+        }
+    }
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -32,6 +32,9 @@ struct BackgroundTaskInner {
 /// dropped.
 #[derive(Clone, Debug)]
 pub struct BackgroundTask {
+    // The task handle is an `Option` so we can `take()` out of it during `drop`, where we have a
+    // mutable reference but need to move out of the underlying task handle to cancel it. This will
+    // always be `Some` except during cancellation.
     inner: Option<Arc<BackgroundTaskInner>>,
 }
 

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -57,11 +57,11 @@ pub struct MockNetwork<D: DataSourceLifeCycle> {
 // convenient type alias.
 pub type MockDataSource = FileSystemDataSource<MockTypes, NoFetching>;
 
-const MINIMUM_NODES: usize = 2;
+pub const NUM_NODES: usize = 2;
 
 impl<D: DataSourceLifeCycle + UpdateStatusData> MockNetwork<D> {
     pub async fn init() -> Self {
-        let (pub_keys, priv_keys): (Vec<_>, Vec<_>) = (0..MINIMUM_NODES)
+        let (pub_keys, priv_keys): (Vec<_>, Vec<_>) = (0..NUM_NODES)
             .map(|i| BLSPubKey::generated_from_seed_indexed([0; 32], i as u64))
             .unzip();
         let total_nodes = NonZeroUsize::new(pub_keys.len()).unwrap();

--- a/src/testing/consensus.rs
+++ b/src/testing/consensus.rs
@@ -11,21 +11,25 @@
 // see <https://www.gnu.org/licenses/>.
 
 use super::mocks::{
-    DataSourceLifeCycle, MockDANetwork, MockMembership, MockNodeImpl, MockQuorumNetwork,
-    MockTransaction, MockTypes,
+    MockDANetwork, MockMembership, MockNodeImpl, MockQuorumNetwork, MockTransaction, MockTypes,
 };
 use crate::{
-    data_source::FileSystemDataSource, fetching::provider::NoFetching, status::UpdateStatusData,
+    availability::AvailabilityDataSource,
+    data_source::{FileSystemDataSource, UpdateDataSource, VersionedDataSource},
+    fetching::provider::NoFetching,
+    node::NodeDataSource,
+    status::{StatusDataSource, UpdateStatusData},
     SignatureKey,
 };
 use async_std::{
     sync::{Arc, RwLock},
     task::spawn,
 };
+use async_trait::async_trait;
 use futures::{future::join_all, stream::StreamExt};
 use hotshot::{
     traits::implementations::{MasterMap, MemoryNetwork, MemoryStorage, NetworkingMetricsValue},
-    types::SystemContextHandle,
+    types::{Event, SystemContextHandle},
     HotShotInitializer, Memberships, Networks, SystemContext,
 };
 use hotshot_types::{
@@ -158,7 +162,9 @@ impl<D: DataSourceLifeCycle + UpdateStatusData> MockNetwork<D> {
         )
         .await;
 
-        Self { nodes, pub_keys }
+        let network = Self { nodes, pub_keys };
+        D::setup(&network).await;
+        network
     }
 }
 
@@ -179,8 +185,12 @@ impl<D: DataSourceLifeCycle> MockNetwork<D> {
         self.pub_keys[i]
     }
 
+    pub fn data_source_index(&self, i: usize) -> Arc<RwLock<D>> {
+        self.nodes[i].data_source.clone()
+    }
+
     pub fn data_source(&self) -> Arc<RwLock<D>> {
-        self.nodes[0].data_source.clone()
+        self.data_source_index(0)
     }
 
     pub fn storage(&self) -> &D::Storage {
@@ -226,4 +236,41 @@ impl<D: DataSourceLifeCycle> Drop for MockNetwork<D> {
     fn drop(&mut self) {
         async_std::task::block_on(self.shut_down_impl())
     }
+}
+
+#[async_trait]
+pub trait DataSourceLifeCycle: Send + Sync + Sized + 'static {
+    /// Backing storage for the data source.
+    ///
+    /// This can be used to connect to data sources to the same underlying data. It must be kept
+    /// alive as long as the related data sources are open.
+    type Storage: Send + Sync;
+
+    async fn create(node_id: usize) -> Self::Storage;
+    async fn connect(storage: &Self::Storage) -> Self;
+    async fn reset(storage: &Self::Storage) -> Self;
+    async fn handle_event(&mut self, event: &Event<MockTypes>);
+
+    /// Setup runs after setting up the network but before starting a test.
+    async fn setup(_network: &MockNetwork<Self>) {}
+}
+
+pub trait TestableDataSource:
+    DataSourceLifeCycle
+    + AvailabilityDataSource<MockTypes>
+    + NodeDataSource<MockTypes>
+    + StatusDataSource
+    + UpdateDataSource<MockTypes>
+    + VersionedDataSource
+{
+}
+
+impl<T> TestableDataSource for T where
+    T: DataSourceLifeCycle
+        + AvailabilityDataSource<MockTypes>
+        + NodeDataSource<MockTypes>
+        + StatusDataSource
+        + UpdateDataSource<MockTypes>
+        + VersionedDataSource
+{
 }

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -10,20 +10,11 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    availability::{AvailabilityDataSource, QueryablePayload},
-    data_source::{UpdateDataSource, VersionedDataSource},
-    node::NodeDataSource,
-    status::StatusDataSource,
-};
-use async_trait::async_trait;
-use hotshot::{
-    traits::{
-        election::static_committee::{GeneralStaticCommittee, StaticElectionConfig},
-        implementations::{MemoryCommChannel, MemoryStorage},
-        NodeImplementation,
-    },
-    types::Event,
+use crate::availability::QueryablePayload;
+use hotshot::traits::{
+    election::static_committee::{GeneralStaticCommittee, StaticElectionConfig},
+    implementations::{MemoryCommChannel, MemoryStorage},
+    NodeImplementation,
 };
 use hotshot_testing::{
     block_types::{TestBlockHeader, TestBlockPayload, TestTransaction},
@@ -105,38 +96,4 @@ impl NodeImplementation<MockTypes> for MockNodeImpl {
     ) -> (ChannelMaps<MockTypes>, Option<ChannelMaps<MockTypes>>) {
         (ChannelMaps::new(start_view), None)
     }
-}
-
-#[async_trait]
-pub trait DataSourceLifeCycle: Send + Sync + Sized + 'static {
-    /// Backing storage for the data source.
-    ///
-    /// This can be used to connect to data sources to the same underlying data. It must be kept
-    /// alive as long as the related data sources are open.
-    type Storage: Send + Sync;
-
-    async fn create(node_id: usize) -> Self::Storage;
-    async fn connect(storage: &Self::Storage) -> Self;
-    async fn reset(storage: &Self::Storage) -> Self;
-    async fn handle_event(&mut self, event: &Event<MockTypes>);
-}
-
-pub trait TestableDataSource:
-    DataSourceLifeCycle
-    + AvailabilityDataSource<MockTypes>
-    + NodeDataSource<MockTypes>
-    + StatusDataSource
-    + UpdateDataSource<MockTypes>
-    + VersionedDataSource
-{
-}
-
-impl<T> TestableDataSource for T where
-    T: DataSourceLifeCycle
-        + AvailabilityDataSource<MockTypes>
-        + NodeDataSource<MockTypes>
-        + StatusDataSource
-        + UpdateDataSource<MockTypes>
-        + VersionedDataSource
-{
 }


### PR DESCRIPTION
Implement `NoStorage` which implements the availability storage interface by returning errors for every query. This lets us really stress test fetching. With a few modifications to the tests and new features we had already planned on implementing, we are able to run the availability tests and have them pass without any persistent storage!

**Test modifications**
* We don't enforce that a query for a non-unique payload or transaction
  returns the _first_ matching object, if the object needs to be fetched.
  We do guarantee this for objects which are stored locally, but there's
  no good way to do it when fetching the object, since the proactive fetcher
  may provide a matching object in any order. This is not a property anybody relies on anyways.
* Moved the proposer queries to a separate test module. Since they are no
  longer part of the availability API, these queries do not support fetching
  and thus don't work with [`NoStorage`]

**New features**
* Use in-memory height when responding to `block-height` queries. This makes the queries faster and puts less pressure on the database. It was needed here because block height would simply not be accurate for the `NoStorage` tests if we tried fetching it from the (fake) database.
* Background task to identify and fetch missing objects. This always decreases the probability that a query will trigger an active fetch or fail due to data being missing, which is very nice. It is particularly important for `NoStorage`, because it allows us to succeed even in queries that use passive fetches.

One more thing I ~want to do~did before making this ready for review: add a timeout for availability endpoint handlers: if the requested resource is not available immediately, wait a short time on par with a normal HTTP response (maybe 500ms or so) to see if the object arrives on time. This will allow us to succeed in cases where an object was missing but we triggered an active fetch for it which quickly succeeds, which should reduce the error rate a lot for nodes with missing or unreliable storage. This in turn may allow us to run the proactive fetcher less frequently, which further reduces load on the CPU and database.

Closes #378 
Closes #386 
Closes #338 