### PR TITLE
Add `/node/sync-status` endpoint to get information about missing data

### DIFF
--- a/api/node.toml
+++ b/api/node.toml
@@ -21,7 +21,8 @@ particular node. It provides access to information that the availability API doe
 information depends on the perspective of the node observing it, and may be subject to eventual
 consistency. For example, `/node/block-height` and `/node/proposals/:proposer_id/count` may both
 return smaller counts than expected, if the node being queried is not fully synced with the entire
-history of the chain. However, the node will _eventually_ sync and return the expected counts.
+history of the chain. However, the node will _eventually_ sync and return the expected counts. See
+`/node/sync-status` for information on how in or out of sync the node currently is.
 """
 
 [route.block_height]
@@ -38,6 +39,8 @@ PATH = ["proposals/:proposer_id/count"]
 DOC = """
 Get the number of committed blocks proposed by `proposer_id`, known to this node.
 
+Warning: count may be low if data is currently being indexed (see `sync-status`).
+
 Returns an integer.
 """
 
@@ -49,6 +52,8 @@ DOC = """
 Get the leaf data of `:count` leaves from the proposer with `:proposer_id`, starting backwards from
 the most recent leaf from this proposer. If the proposer has proposed fewer leaves than `:count`,
 return all the leaves from the proposer.
+
+Warning: response may be incomplete if data is currently being indexed (see `sync-status`).
 
 Returns a list of
 
@@ -62,6 +67,20 @@ Returns a list of
         "proposer_id": TaggedBase64,
     },
     "qc": QC,
+}
+```
+"""
+
+[route.sync_status]
+PATH = ["sync-status"]
+DOC = """
+Get the node's progress in syncing with the latest state of the blockchain.
+
+Returns
+```
+{
+	"missing_blocks": integer,
+	"missing_leaves": integer,
 }
 ```
 """

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -215,6 +215,13 @@ impl<Types: NodeType> LeafQueryData<Types> {
         Ok(Self { leaf, qc })
     }
 
+    pub fn genesis(instance_state: &Types::InstanceState) -> Self {
+        Self {
+            leaf: Leaf::genesis(instance_state),
+            qc: QuorumCertificate::genesis(),
+        }
+    }
+
     pub fn leaf(&self) -> &Leaf<Types> {
         &self.leaf
     }
@@ -265,6 +272,11 @@ impl<Types: NodeType> BlockQueryData<Types> {
             size: payload_size::<Types>(&payload),
             payload,
         }
+    }
+
+    pub fn genesis(instance_state: &Types::InstanceState) -> Self {
+        let (header, payload, _) = Types::BlockHeader::genesis(instance_state);
+        Self::new(header, payload)
     }
 
     pub fn header(&self) -> &Header<Types> {

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -520,9 +520,14 @@ pub mod persistence_tests {
 #[espresso_macros::generic_tests]
 pub mod node_tests {
     use super::test_helpers::*;
-    use crate::testing::{
-        consensus::{MockNetwork, TestableDataSource},
-        setup_test,
+    use crate::{
+        availability::{BlockQueryData, LeafQueryData, UpdateAvailabilityData},
+        node::SyncStatus,
+        testing::{
+            consensus::{MockNetwork, TestableDataSource},
+            mocks::MockTypes,
+            setup_test,
+        },
     };
     use futures::stream::StreamExt;
     use std::collections::HashSet;
@@ -606,6 +611,93 @@ pub mod node_tests {
         let _ = ds.read().await;
         let storage = D::connect(network.storage()).await;
         validate(&storage).await;
+    }
+
+    #[async_std::test]
+    pub async fn test_sync_status<D: TestableDataSource>() {
+        setup_test();
+
+        let storage = D::create(0).await;
+        let mut ds = D::connect(&storage).await;
+
+        // Generate some mock leaves and blocks to insert.
+        let mut leaves = vec![LeafQueryData::<MockTypes>::genesis()];
+        let mut blocks = vec![BlockQueryData::<MockTypes>::genesis()];
+        for i in 0..3 {
+            let mut leaf = leaves[i].clone();
+            leaf.leaf.block_header.block_number += 1;
+            leaves.push(leaf);
+
+            let mut block = blocks[i].clone();
+            block.header.block_number += 1;
+            blocks.push(block);
+        }
+
+        // At first, the node is fully synced.
+        assert_eq!(
+            ds.sync_status().await.unwrap(),
+            SyncStatus {
+                missing_blocks: 0,
+                missing_leaves: 0,
+            }
+        );
+
+        // Insert a leaf without the corresponding block, make sure we detect that the block is
+        // missing.
+        UpdateAvailabilityData::insert_leaf(&mut ds, leaves[1].clone())
+            .await
+            .unwrap();
+        ds.commit().await.unwrap();
+        assert_eq!(
+            ds.sync_status().await.unwrap(),
+            SyncStatus {
+                missing_blocks: 1,
+                missing_leaves: 0,
+            }
+        );
+
+        // Insert a leaf whose height is not the successor of the previous leaf. We should now
+        // detect that the leaf in between is missing (along with all _three_ corresponding blocks).
+        UpdateAvailabilityData::insert_leaf(&mut ds, leaves[3].clone())
+            .await
+            .unwrap();
+        ds.commit().await.unwrap();
+        assert_eq!(
+            ds.sync_status().await.unwrap(),
+            SyncStatus {
+                missing_blocks: 3,
+                missing_leaves: 1,
+            }
+        );
+
+        // Rectify the missing data.
+        ds.insert_block(blocks[1].clone()).await.unwrap();
+        UpdateAvailabilityData::insert_leaf(&mut ds, leaves[2].clone())
+            .await
+            .unwrap();
+        ds.insert_block(blocks[2].clone()).await.unwrap();
+        ds.insert_block(blocks[3].clone()).await.unwrap();
+        ds.commit().await.unwrap();
+
+        // Some data sources (e.g. file system) don't support out-of-order insertion of missing
+        // data. These would have just ignored the insertion of `leaves[2]`. Detect if this is the
+        // case; then we allow 1 missing leaf remaining.
+        let expected_missing_leaves = if ds.get_leaf(2).await.try_resolve().is_err() {
+            tracing::warn!(
+                "data source does not support out-of-order filling, allowing one missing leaf"
+            );
+            1
+        } else {
+            0
+        };
+
+        assert_eq!(
+            ds.sync_status().await.unwrap(),
+            SyncStatus {
+                missing_blocks: 0,
+                missing_leaves: expected_missing_leaves
+            }
+        );
     }
 }
 

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -18,7 +18,7 @@ use crate::{
         UpdateAvailabilityData,
     },
     metrics::PrometheusMetrics,
-    node::{NodeDataSource, UpdateNodeData},
+    node::{NodeDataSource, SyncStatus, UpdateNodeData},
     status::StatusDataSource,
     Payload, QueryResult, SignatureKey,
 };
@@ -223,6 +223,9 @@ where
     }
     async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize> {
         self.data_source.count_proposals(proposer).await
+    }
+    async fn sync_status(&self) -> QueryResult<SyncStatus> {
+        self.data_source.sync_status().await
     }
 }
 

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -86,7 +86,7 @@ use crate::{
         Callback, Provider,
     },
     metrics::PrometheusMetrics,
-    node::{NodeDataSource, UpdateNodeData},
+    node::{NodeDataSource, SyncStatus, UpdateNodeData},
     status::StatusDataSource,
     task::BackgroundTask,
     Header, NotFoundSnafu, Payload, QueryResult, SignatureKey,
@@ -509,6 +509,10 @@ where
 
     async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize> {
         self.storage().await.count_proposals(proposer).await
+    }
+
+    async fn sync_status(&self) -> QueryResult<SyncStatus> {
+        self.storage().await.sync_status().await
     }
 }
 

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -25,7 +25,7 @@ use crate::{
         },
     },
     data_source::VersionedDataSource,
-    node::{NodeDataSource, UpdateNodeData},
+    node::{NodeDataSource, SyncStatus, UpdateNodeData},
     Header, MissingSnafu, NotFoundSnafu, Payload, QueryResult, SignatureKey,
 };
 use async_trait::async_trait;
@@ -412,6 +412,14 @@ where
         Ok(match self.index_by_proposer_id.get(id) {
             Some(ids) => ids.len(),
             None => 0,
+        })
+    }
+
+    async fn sync_status(&self) -> QueryResult<SyncStatus> {
+        let height = self.block_height().await?;
+        Ok(SyncStatus {
+            missing_blocks: self.block_storage.missing(height),
+            missing_leaves: self.leaf_storage.missing(height),
         })
     }
 }

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -19,7 +19,7 @@ use crate::{
         TransactionHash, TransactionIndex, UpdateAvailabilityData,
     },
     data_source::VersionedDataSource,
-    node::{NodeDataSource, UpdateNodeData},
+    node::{NodeDataSource, SyncStatus, UpdateNodeData},
     Header, Payload, QueryError, QueryResult, SignatureKey,
 };
 use async_trait::async_trait;
@@ -138,6 +138,10 @@ where
     }
 
     async fn count_proposals(&self, _id: &SignatureKey<Types>) -> QueryResult<usize> {
+        Err(QueryError::Missing)
+    }
+
+    async fn sync_status(&self) -> QueryResult<SyncStatus> {
         Err(QueryError::Missing)
     }
 }
@@ -437,6 +441,13 @@ pub mod testing {
             match self {
                 Self::Sql(data_source) => data_source.count_proposals(proposer).await,
                 Self::NoStorage(data_source) => data_source.count_proposals(proposer).await,
+            }
+        }
+
+        async fn sync_status(&self) -> QueryResult<SyncStatus> {
+            match self {
+                Self::Sql(data_source) => data_source.sync_status().await,
+                Self::NoStorage(data_source) => data_source.sync_status().await,
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@
 //! #   PayloadQueryData, TransactionHash, TransactionIndex,
 //! # };
 //! # use hotshot_query_service::metrics::PrometheusMetrics;
-//! # use hotshot_query_service::node::NodeDataSource;
+//! # use hotshot_query_service::node::{NodeDataSource, SyncStatus};
 //! # use hotshot_query_service::status::StatusDataSource;
 //! # use hotshot_query_service::testing::mocks::MockTypes as AppTypes;
 //! # use std::ops::RangeBounds;
@@ -334,6 +334,10 @@
 //!
 //!     async fn count_proposals(&self, id: &SignatureKey<AppTypes>) -> QueryResult<usize> {
 //!         self.hotshot_qs.count_proposals(id).await
+//!     }
+//!
+//!     async fn sync_status(&self) -> QueryResult<SyncStatus> {
+//!         self.hotshot_qs.sync_status().await
 //!     }
 //! }
 //!
@@ -512,7 +516,7 @@ mod test {
             PayloadQueryData, TransactionHash, TransactionIndex,
         },
         metrics::PrometheusMetrics,
-        node::NodeDataSource,
+        node::{NodeDataSource, SyncStatus},
         status::StatusDataSource,
         testing::{
             consensus::MockDataSource,
@@ -619,6 +623,9 @@ mod test {
         }
         async fn count_proposals(&self, proposer: &SignatureKey<MockTypes>) -> QueryResult<usize> {
             self.hotshot_qs.count_proposals(proposer).await
+        }
+        async fn sync_status(&self) -> QueryResult<SyncStatus> {
+            self.hotshot_qs.sync_status().await
         }
     }
 

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -10,7 +10,7 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use super::query_data::LeafQueryData;
+use super::query_data::{LeafQueryData, SyncStatus};
 use crate::{QueryResult, SignatureKey};
 use async_trait::async_trait;
 use hotshot_types::traits::node_implementation::NodeType;
@@ -26,6 +26,7 @@ pub trait NodeDataSource<Types: NodeType> {
         limit: Option<usize>,
     ) -> QueryResult<Vec<LeafQueryData<Types>>>;
     async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize>;
+    async fn sync_status(&self) -> QueryResult<SyncStatus>;
 }
 
 #[async_trait]

--- a/src/node/query_data.rs
+++ b/src/node/query_data.rs
@@ -10,4 +10,12 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use serde::{Deserialize, Serialize};
+
 pub use crate::availability::LeafQueryData;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+pub struct SyncStatus {
+    pub missing_blocks: usize,
+    pub missing_leaves: usize,
+}


### PR DESCRIPTION
This endpoint can be used to determine if the database is fully
synced and, if not, how much data is missing. This is useful for
alerts (@Ancient123) as well as for the block explorer to be able to inform the
user when aggregate queries may be inaccurate due to syncing in
progress (@Ayiga).

The query used to count missing data is not indexed or optimized,
but I believe it can be made efficient in the future:
* The `count(*)` to determine the number of leaves we have can be
  slow when the `leaf` table is large, because Postgres uses a full
  table scan to count. This could be made more efficient a number of
  ways, including:
  - Using estimated counts instead of exact counts
  - Storing in the database the latest count and using triggers to
    update it on inserts/updates
  - Inserting placeholder rows with NULL columns for leaves we don't
    have. This would ensure that there is a row for each possible leaf
    height, and the presence or absence of the leaf becomese a boolean
    property we can express on that row. Instead of counting over the
    entire table, we only need to count `WHERE data IS NULL` or similar,
    and we can use an index to efficiently process that filter.
* The `WHERE data IS NULL` filter for counting missing payloads is not
  indexed. We will add an index there after we test with a large enough
  database to be confident that Postgres is using the index and it is
  improving performance.

These optimizations are intentionally left as future work, for after we
have run this for some time and with large enough datasets that we can
really see the effects of various optimization strategies.

Of course, another approach to optimization would be to keep the count
of missing blocks and leaves in memory, and maintain it whenever we
`insert_block` or `insert_leaf` -- dead reckoning. This would probably
be the most efficient approach, but since this endpoint is designed to
be used for alerting and detecting low-level incidents like bugs in the
storage layer or failures in RDS, in many of the situations we care about,
the actual state of the database could end up diverging from our dead
reckoning estimate, and we might miss an incident. Therefore, I think
the endpoint is much more useful if it is running some meaningful
query over the actual data.

Closes #362
