### PR TITLE
Add Block Summaries Endpoints

### DIFF
--- a/api/availability.toml
+++ b/api/availability.toml
@@ -197,3 +197,20 @@ Get the stake table after `:height` leaves or after `:view_number`.
 
 Returns a map from staking public keys to amounts.
 """
+
+
+[route.get_block_summary]
+PATH = ["block/summary/:height"]
+":height" = "Integer"
+DOC = """
+Get the Block Summary for a block based on its position in the ledger.
+"""
+
+[route.get_block_summary_range]
+PATH = ["block/summaries/:from/:until"]
+":from" = "Integer"
+":until" = "Integer"
+DOC = """
+Get the Block Summary entries for blocks based on their position in the ledger,
+the blocks are taken starting from the given :from up until the given :until.
+"""

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -500,10 +500,7 @@ mod test {
             assert_eq!(block_summary.header(), block.header());
             assert_eq!(block_summary.hash(), block.hash());
             assert_eq!(block_summary.size(), block.size());
-            assert_eq!(
-                block_summary.num_transactions(),
-                block.num_transactions() as u64
-            );
+            assert_eq!(block_summary.num_transactions(), block.num_transactions());
 
             let block_summaries: Vec<BlockSummaryQueryData<MockTypes>> = client
                 .get(&format!("block/summaries/{}/{}", 0, i))

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -429,3 +429,84 @@ pub(crate) fn payload_size<Types: NodeType>(payload: &Payload<Types>) -> u64 {
         Err(_) => 0,
     }
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(bound = "")]
+pub struct BlockSummaryQueryData<Types: NodeType> {
+    pub(crate) header: Header<Types>,
+    pub(crate) hash: BlockHash<Types>,
+    pub(crate) size: u64,
+    pub(crate) num_transactions: u64,
+    pub(crate) proposer_id: SignatureKey<Types>,
+}
+
+// Add some basic getters to the BlockSummaryQueryData type.
+impl<Types: NodeType> BlockSummaryQueryData<Types> {
+    pub fn header(&self) -> &Header<Types> {
+        &self.header
+    }
+
+    pub fn hash(&self) -> BlockHash<Types> {
+        self.hash
+    }
+
+    pub fn height(&self) -> u64 {
+        self.header.block_number()
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn num_transactions(&self) -> u64 {
+        self.num_transactions
+    }
+
+    pub fn proposer_id(&self) -> SignatureKey<Types> {
+        self.proposer_id.clone()
+    }
+}
+
+// Get the Proposer from the given header.  At the moment the proposer cannot
+// be determined from the header, however it is intended to in the future.
+// For now we will just generate one with dummy data.
+// TODO update this function to retrieve the proposer from the Header type once
+//      the Header type has been updated to include the proposer.
+pub fn get_proposer<Types: NodeType>(_header: &Header<Types>) -> SignatureKey<Types> {
+    use hotshot::types::SignatureKey;
+    let (key, _) = SignatureKey::generated_from_seed_indexed([0; 32], 0);
+    key
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(bound = "")]
+pub struct TransactionSummaryQueryData<Types: NodeType> {
+    pub(crate) hash: TransactionHash<Types>,
+    pub(crate) header: Header<Types>,
+    // We want a way to determine a summary for each rollup entry, without
+    // the data directly, but rather a summary of the data.
+    // For now, we'll roll with the `Payload` itself.
+    pub(crate) transaction: Transaction<Types>,
+}
+
+// Since BlockSummaryQueryData can be derived entirely from BlockQueryData, we
+// implement the From trait to allow for a seamless conversion using rust
+// contentions.
+impl<Types: NodeType> From<BlockQueryData<Types>> for BlockSummaryQueryData<Types>
+where
+    Payload<Types>: QueryablePayload,
+{
+    fn from(value: BlockQueryData<Types>) -> Self {
+        let payload = value.payload();
+        let size = payload_size::<Types>(&payload.clone());
+        let num_transactions = payload.len(value.metadata());
+
+        BlockSummaryQueryData {
+            header: value.header().clone(),
+            hash: value.hash(),
+            size,
+            num_transactions: num_transactions as u64,
+            proposer_id: get_proposer::<Types>(value.header()),
+        }
+    }
+}

--- a/src/data_source/update.rs
+++ b/src/data_source/update.rs
@@ -11,9 +11,12 @@
 // see <https://www.gnu.org/licenses/>.
 
 //! A generic algorithm for updating a HotShot Query Service data source with new data.
-use crate::availability::{BlockQueryData, LeafQueryData, UpdateAvailabilityData};
+use crate::availability::{
+    BlockQueryData, LeafQueryData, QueryablePayload, UpdateAvailabilityData,
+};
 use crate::node::UpdateNodeData;
 use crate::status::UpdateStatusData;
+use crate::Payload;
 use async_trait::async_trait;
 use hotshot::types::{Event, EventType};
 use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
@@ -59,6 +62,7 @@ where
         + UpdateNodeData<Types, Error = <Self as UpdateAvailabilityData<Types>>::Error>
         + UpdateStatusData
         + Send,
+    Payload<Types>: QueryablePayload,
 {
     async fn update(
         &mut self,


### PR DESCRIPTION
For the sake of the Block Explorer, as well as potential future utility we
find ourselves in need of a data structure that can describe aspects of
a Block without transmitting the full contents of a Block.  Currently, we
would like the ability to retrieve a Summary of a Block that indicates the
properties of a Block, as well as a summary of how many transactions
are contained within the Block.  In addition we find ourselves needing
to be able to grab a range of these Block Summaries for Pagination
and comparison purposes.

Add BlockSummaryQueryData type

The BlockSummaryQueryData defines the data layout of the Block
Summary endpoints.

Add From trait for BlockQuerySummaryData from BlockQueryData

Since the BlockQuerySummaryData will eventually be able to be
generated entirely from the BlockQueryData, it makes sense to be
able to actively convert to the Summary type given a Block itself.

Add get_block_summary endpoint

This endpoint can retrieve a single block_summary for a given
block height to indicate its position within the ledger.

Add get_block_summary_range endpoint

This endpoint allows us to retrieve a a range of block summaries
so we can grab a collection of them for direct reference.