### PR TITLE
pin hotshot to tag instead of using rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2804,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "serde",
 ]
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2884,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2903,7 +2903,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2928,7 +2928,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "ark-bls12-381",
  "ark-ed-on-bn254",
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?rev=3f4f488a#3f4f488a40d68998045e32756eff58518c478369"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.12#3f4f488a40d68998045e32756eff58518c478369"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.10"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "3f4f488a" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "3f4f488a" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "3f4f488a" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.12" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.12" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.12" }
 itertools = "0.12.1"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
@@ -105,7 +105,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "3f4f488a", optional = true }
+hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.12", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -125,7 +125,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 # Adding since it was showing some warnings in the `testing/mocks.rs`
-hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", rev = "3f4f488a" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.12" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"


### PR DESCRIPTION
This updates query service to use a tag instead of revision. The tag was pushed to reference the same revision, so nothing should change except for the way we reference the version in our Cargo.toml. Using the `rev` was only intended as a temporary solution to avoid creating a bunch of tags while we making a lot of changes..