### PR TITLE
Add aggregate endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,6 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout Repository
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Configure Git
@@ -69,7 +66,7 @@ jobs:
 
       - name: Generate Documentation
         run: |
-          cargo doc --no-deps --lib --release
+          cargo doc --no-deps --lib --release --all-features
           echo '<meta http-equiv="refresh" content="0; url=hotshot_query_service">' > target/doc/index.html
 
       - name: Deploy Documentation

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -37,9 +37,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - name: Checkout Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -12,9 +12,6 @@ jobs:
         RUST_LOG: info
         RUST_MIN_STACK: '3145728'
     steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,9 +40,6 @@ jobs:
       - uses: actions/checkout@v4
         name: Checkout Repository
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Configure Git

--- a/api/node.toml
+++ b/api/node.toml
@@ -71,6 +71,26 @@ Returns a list of
 ```
 """
 
+[route.count_transactions]
+PATH = ["transactions/count"]
+DOC = """
+Get the number of transactions in the chain.
+
+Warning: count may be low if data is currently being indexed (see `sync-status`).
+
+Returns an integer.
+"""
+
+[route.payload_size]
+PATH = ["payloads/total-size"]
+DOC = """
+Get the size (in bytes) of all payload data in the chain.
+
+Warning: size may be low if data is currently being indexed (see `sync-status`).
+
+Returns an integer.
+"""
+
 [route.sync_status]
 PATH = ["sync-status"]
 DOC = """

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,6 @@
               nixpkgs-fmt
               git
               mdbook # make-doc, documentation generation
-              protobuf
               rustToolchain
             ] ++ myPython ++ rustDeps;
 
@@ -183,7 +182,7 @@
           perfShell = pkgs.mkShell {
             shellHook = shellHook;
             buildInputs = with pkgs;
-              [ nixWithFlakes cargo-llvm-cov rustToolchain protobuf ] ++ rustDeps;
+              [ nixWithFlakes cargo-llvm-cov rustToolchain ] ++ rustDeps;
 
             inherit RUST_SRC_PATH RUST_BACKTRACE RUST_LOG RUSTFLAGS;
           };

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -18,7 +18,7 @@ use crate::{
         UpdateAvailabilityData,
     },
     metrics::PrometheusMetrics,
-    node::{NodeDataSource, SyncStatus, UpdateNodeData},
+    node::{NodeDataSource, SyncStatus},
     status::StatusDataSource,
     Payload, QueryResult, SignatureKey,
 };
@@ -224,22 +224,14 @@ where
     async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize> {
         self.data_source.count_proposals(proposer).await
     }
+    async fn count_transactions(&self) -> QueryResult<usize> {
+        self.data_source.count_transactions().await
+    }
+    async fn payload_size(&self) -> QueryResult<usize> {
+        self.data_source.payload_size().await
+    }
     async fn sync_status(&self) -> QueryResult<SyncStatus> {
         self.data_source.sync_status().await
-    }
-}
-
-#[async_trait]
-impl<D, U, Types> UpdateNodeData<Types> for ExtensibleDataSource<D, U>
-where
-    D: UpdateNodeData<Types> + Send + Sync,
-    U: Send + Sync,
-    Types: NodeType,
-{
-    type Error = D::Error;
-
-    async fn insert_leaf(&mut self, leaf: LeafQueryData<Types>) -> Result<(), Self::Error> {
-        self.data_source.insert_leaf(leaf).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,6 +336,14 @@
 //!         self.hotshot_qs.count_proposals(id).await
 //!     }
 //!
+//!     async fn count_transactions(&self) -> QueryResult<usize> {
+//!         self.hotshot_qs.count_transactions().await
+//!     }
+//!
+//!     async fn payload_size(&self) -> QueryResult<usize> {
+//!         self.hotshot_qs.payload_size().await
+//!     }
+//!
 //!     async fn sync_status(&self) -> QueryResult<SyncStatus> {
 //!         self.hotshot_qs.sync_status().await
 //!     }
@@ -625,6 +633,12 @@ mod test {
         }
         async fn count_proposals(&self, proposer: &SignatureKey<MockTypes>) -> QueryResult<usize> {
             self.hotshot_qs.count_proposals(proposer).await
+        }
+        async fn count_transactions(&self) -> QueryResult<usize> {
+            self.hotshot_qs.count_transactions().await
+        }
+        async fn payload_size(&self) -> QueryResult<usize> {
+            self.hotshot_qs.payload_size().await
         }
         async fn sync_status(&self) -> QueryResult<SyncStatus> {
             self.hotshot_qs.sync_status().await

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -10,12 +10,24 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+//! Data for the [`node`](super) API.
+//!
+//! This module is just an alternative view of the same data provided by the
+//! [`availability`](crate::availability) API. It provides more insight into what data the node
+//! actually has at present, as opposed to trying to present a perfect view of an abstract chain,
+//! fetching data from other sources as needed. It is also more liberal with provided aggregate
+//! counts and statistics which may be inaccurate if data is missing.
+//!
+//! Due to this relationship with the availability module, this module has its own [data source
+//! trait](`NodeDataSource`) but not its own update trait. The node data source is expected to read
+//! its data from the same underlying database as the availability API, and as such the data is
+//! updated implicitly via the [availability API update
+//! trait](crate::availability::UpdateAvailabilityData).
+
 use super::query_data::{LeafQueryData, SyncStatus};
 use crate::{QueryResult, SignatureKey};
 use async_trait::async_trait;
 use hotshot_types::traits::node_implementation::NodeType;
-use std::error::Error;
-use std::fmt::Debug;
 
 #[async_trait]
 pub trait NodeDataSource<Types: NodeType> {
@@ -26,11 +38,7 @@ pub trait NodeDataSource<Types: NodeType> {
         limit: Option<usize>,
     ) -> QueryResult<Vec<LeafQueryData<Types>>>;
     async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize>;
+    async fn count_transactions(&self) -> QueryResult<usize>;
+    async fn payload_size(&self) -> QueryResult<usize>;
     async fn sync_status(&self) -> QueryResult<SyncStatus>;
-}
-
-#[async_trait]
-pub trait UpdateNodeData<Types: NodeType> {
-    type Error: Error + Debug + Send + Sync + 'static;
-    async fn insert_leaf(&mut self, leaf: LeafQueryData<Types>) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
We now have endpoints to get the total number of transactions
sequenced and the total size of all data sequenced. This is useful
for the block explorer, internal reporting, and marketing.

I also deleted the `UpdateNodeData` trait because it was a headache
to maintain and didn't really accomplish anything that the
`UpdateAvailabilityData` trait didn't already do. In fact, it just
made it confusing what trait was supposed to do what. It is now
explicitly documented that the node module uses the same underlying
data as the availability module.

Closes #342