### PR TITLE
Add endpoint for transaction pagination reverse order

### DIFF
--- a/api/availability.toml
+++ b/api/availability.toml
@@ -277,3 +277,14 @@ DOC = """
 Get the Block Summary entries for blocks based on their position in the ledger,
 the blocks are taken starting from the given :from up until the given :until.
 """
+
+
+[route.get_transaction_range_rev]
+PATH = ["transaction/range/rev/:height/:offset/:limit"]
+":height" = "Integer"
+":offset" = "Integer"
+":limit" = "Integer"
+DOC = """
+Retrieves a list of transactions up to the requested limit, starting from the
+given block height and working
+"""

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -498,7 +498,7 @@ where
                         // We need to reverse here, otherwise we're not in the correct order.
                         vec_of_blocks.into_iter().rev()
                     })
-                    .flat_map(|iter| futures::stream::iter(iter));
+                    .flat_map(futures::stream::iter);
 
                 let chunked_transactions = stream_of_chunked_blocks.map(|result| match result {
                     Ok(block) => {

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -540,8 +540,6 @@ fn build_range_iterator_rev(
 
     (0..steps)
         .map(move |chunk| {
-            // We start at the back such that step 0 *should* have it's
-            // end being the overall desired end size.
             let start = chunk * chunk_size;
             let end = min(end, start + chunk_size);
 

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -868,6 +868,26 @@ mod test {
                 .unwrap();
 
             assert_eq!(header_range.len() as u64, i);
+
+            let transactions: Vec<Transaction<MockTypes>> = client
+                .get(&format!(
+                    "transaction/range/rev/{}/{}/{}",
+                    block.height(),
+                    0,
+                    block.num_transactions
+                ))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(transactions.len() as u64, block.num_transactions);
+            transactions
+                .into_iter()
+                .rev()
+                .zip(block.enumerate().map(|(_, txn)| txn))
+                .for_each(|(txn, txn_from_block)| {
+                    assert_eq!(txn, txn_from_block);
+                });
         }
     }
 


### PR DESCRIPTION
There is a need to be able to retrieve the various entries of
the HotShot Query Service Availability Endpoints as ranges of
data in addition to single entries.

This change adds an endpoint that allows us to retrieve
transactions in a paginated manner provided we have a start
block height and offset that allows us to address the specific
transaction entry, and a limit that allows us to specify how
many transaction entries we want.  These three pieces of
information will ultimately allow for us to retrieve as many
transactions as we can.  This can also allow for pagination
for transactions.