### PR TITLE
Status endpoint for elapsed time since last block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,8 +1276,10 @@ checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -2844,7 +2846,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2883,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "serde",
 ]
@@ -2891,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2922,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2954,6 +2956,7 @@ dependencies = [
  "atomic_store",
  "backtrace-on-stack-overflow",
  "bincode",
+ "chrono",
  "clap",
  "cld",
  "commit",
@@ -2994,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3007,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3016,6 +3019,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bitvec",
+ "chrono",
  "commit",
  "either",
  "futures",
@@ -3033,7 +3037,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "ark-bls12-381",
  "ark-ed-on-bn254",
@@ -3078,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3087,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4011,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.14#696de65a40c42accc589a368cbbe218bdec90aa3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.15#f73a90c06edd2961d543210a05e9b1565a5a7cef"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -6147,9 +6151,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -6167,9 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6187,9 +6191,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.10"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.14" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.14" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.14" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.15" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.15" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.15" }
 itertools = "0.12.1"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
@@ -87,6 +87,7 @@ time = "0.3"
 toml = "0.8"
 tracing = "0.1"
 trait-variant = "0.1"
+chrono = "0.4"
 
 # Dependencies enabled by feature "file-system-data-source".
 atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", tag = "0.1.3", optional = true }
@@ -105,7 +106,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.14", optional = true }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.15", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -124,7 +125,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.14" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.15" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"

--- a/api/status.toml
+++ b/api/status.toml
@@ -57,6 +57,14 @@ Get the view success rate.
 Returns the fraction of views which resulted in a committed block, as a floating point number.
 """
 
+[route.time_since_last_decide]
+PATH = ["/time-since-last-decide"]
+DOC = """
+Get the time elapsed since the last decided time.
+
+Returns the time elapsed in seconds since the Unix epoch.
+"""
+
 [route.metrics]
 PATH = ["/metrics"]
 METHOD = "METRICS"

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -772,6 +772,15 @@ pub mod status_tests {
             // With consensus paused, check that the success rate returns NAN (since the block
             // height, the numerator, is 0, and the view number, the denominator, is 0).
             assert!(ds.success_rate().await.unwrap().is_nan());
+            // Since there is no block produced, "last_decided_time" metric is 0.
+            // Therefore, the elapsed time since the last block should be close to the time elapsed since the Unix epoch.
+            assert!(
+                (ds.elapsed_time_since_last_decide().await.unwrap() as i64
+                    - chrono::Utc::now().timestamp())
+                .abs()
+                    <= 1,
+                "time elapsed since last_decided_time is not within 1s"
+            );
         }
 
         // Submit a transaction, and check that it is reflected in the mempool.
@@ -850,6 +859,22 @@ pub mod status_tests {
                     transaction_count: 0,
                     memory_footprint: 0,
                 }
+            );
+        }
+
+        {
+            // Shutting down the consensus to halt block production
+            // Introducing a delay of 3 seconds to ensure that elapsed time since last block is atleast 3seconds
+            network.shut_down().await;
+            sleep(Duration::from_secs(3)).await;
+            // Asserting that the elapsed time since the last block is at least 3 seconds
+            assert!(
+                ds.read()
+                    .await
+                    .elapsed_time_since_last_decide()
+                    .await
+                    .unwrap()
+                    >= 3
             );
         }
     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -98,6 +98,15 @@ where
         .get("success_rate", |_, state| {
             async { state.success_rate().await.map_err(internal) }.boxed()
         })?
+        .get("time_since_last_decide", |_, state| {
+            async {
+                state
+                    .elapsed_time_since_last_decide()
+                    .await
+                    .map_err(internal)
+            }
+            .boxed()
+        })?
         .metrics("metrics", |_, state| {
             async { Ok(Cow::Borrowed(state.metrics())) }.boxed()
         })?;


### PR DESCRIPTION
addresses: https://github.com/EspressoSystems/hotshot-query-service/issues/411

Changes:

- Added status /time_since_last_decide endpoint to retrieve time since last block commit.
- Updated hotshot crates to version 0.5.15.