### PR TITLE
VID improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "serde",
 ]
@@ -2895,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3040,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "ark-bls12-381",
  "ark-ed-on-bn254",
@@ -3085,7 +3085,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3094,7 +3094,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,8 +2074,8 @@ checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
-source = "git+https://github.com/dtolnay/dyn-clone?tag=1.0.16#f2f0a02f1f7190048153e5ea8f554db7377a50a9"
+version = "1.0.17"
+source = "git+https://github.com/dtolnay/dyn-clone?tag=1.0.17#51bf8816be5a73e38b59fd4d9dda2bc18e9c2429"
 
 [[package]]
 name = "ed25519"
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "serde",
 ]
@@ -2895,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2999,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3012,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3039,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "ark-bls12-381",
  "ark-ed-on-bn254",
@@ -3058,7 +3058,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "displaydoc",
- "dyn-clone 1.0.16 (git+https://github.com/dtolnay/dyn-clone?tag=1.0.16)",
+ "dyn-clone 1.0.17",
  "either",
  "espresso-systems-common 0.4.1",
  "ethereum-types",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3545,7 +3545,7 @@ dependencies = [
  "derivative",
  "displaydoc",
  "downcast-rs",
- "dyn-clone 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dyn-clone 1.0.16",
  "espresso-systems-common 0.4.0",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
@@ -3623,7 +3623,7 @@ dependencies = [
  "derivative",
  "displaydoc",
  "downcast-rs",
- "dyn-clone 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dyn-clone 1.0.16",
  "hashbrown 0.14.3",
  "itertools 0.12.1",
  "jf-utils",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.17#5e6730a2e313e64498be9c7e66848b63aa389d4a"
+source = "git+https://github.com/EspressoSystems/HotShot.git?branch=refactor-genesis-commitment#0211d6f3b935be5e260c8de903ff749c6d13d3c5"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,7 @@ dependencies = [
  "either",
  "espresso-macros",
  "futures",
+ "generic-array",
  "hotshot",
  "hotshot-example-types",
  "hotshot-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3535,7 +3535,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3635,7 +3635,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#bffc0198a89c195e42f394a4acf2eebf1db8ad5b"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=0.4.0#214227e0608c231cb55234809727723c2a6740c2"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "serde",
 ]
@@ -2895,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2926,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -2975,6 +2975,7 @@ dependencies = [
  "hotshot-utils",
  "include_dir",
  "itertools 0.12.1",
+ "jf-primitives",
  "native-tls",
  "portpicker",
  "postgres-native-tls",
@@ -3000,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3013,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3030,6 +3031,7 @@ dependencies = [
  "hotshot-task",
  "hotshot-types",
  "hotshot-utils",
+ "jf-primitives",
  "sha2 0.10.8",
  "snafu",
  "time 0.3.34",
@@ -3040,9 +3042,10 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "ark-bls12-381",
+ "ark-ec",
  "ark-ed-on-bn254",
  "ark-ff",
  "ark-serialize 0.4.2",
@@ -3069,6 +3072,7 @@ dependencies = [
  "jf-plonk",
  "jf-primitives",
  "jf-utils",
+ "lazy_static",
  "libp2p-networking",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3085,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3094,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4018,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.18#be36bb0e3e8596f7adad3606cf833f9117e028bd"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.19#1e976042e93d9a352ed8ce4f67c806adceb6c6a3"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
+generic-array = "0.14"
 hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
 portpicker = "0.1"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,11 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.10"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.19" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.19" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.19" }
 itertools = "0.12.1"
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.0" }
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
@@ -106,7 +107,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18", optional = true }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.19", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -126,7 +127,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 generic-array = "0.14"
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.19" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.10"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.17" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.17" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.17" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
 itertools = "0.12.1"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
@@ -106,7 +106,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.17", optional = true }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -125,7 +125,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.17" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.10"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
 itertools = "0.12.1"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
@@ -106,7 +106,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment", optional = true }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -126,7 +126,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 generic-array = "0.14"
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", branch = "refactor-genesis-commitment" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.18" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"

--- a/src/availability/data_source.rs
+++ b/src/availability/data_source.rs
@@ -17,12 +17,12 @@ use super::{
         TransactionHash, TransactionIndex, VidCommonQueryData,
     },
 };
-use crate::{Payload, VidShare};
+use crate::{Payload, VidCommitment, VidShare};
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::{Display, From};
 use futures::stream::{BoxStream, Stream, StreamExt};
-use hotshot_types::{data::VidCommitment, traits::node_implementation::NodeType};
+use hotshot_types::traits::node_implementation::NodeType;
 use std::{cmp::Ordering, error::Error, fmt::Debug, ops::RangeBounds};
 
 #[derive(Derivative, From, Display)]

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -285,8 +285,8 @@ impl<Types: NodeType> BlockQueryData<Types> {
     where
         Payload<Types>: QueryablePayload,
     {
-        let (header, payload, _) = Types::BlockHeader::genesis(instance_state);
-        Self::new(header, payload)
+        let leaf = Leaf::<Types>::genesis(instance_state);
+        Self::new(leaf.block_header, leaf.block_payload.unwrap())
     }
 
     pub fn header(&self) -> &Header<Types> {

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -568,9 +568,10 @@ pub mod node_tests {
         state_types::TestInstanceState,
     };
     use hotshot_types::{
-        data::{test_srs, VidScheme, VidSchemeTrait},
         traits::block_contents::{vid_commitment, BlockPayload},
+        vid::{vid_scheme, VidSchemeType},
     };
+    use jf_primitives::vid::VidScheme;
     use std::collections::HashSet;
 
     async fn validate(ds: &impl TestableDataSource) {
@@ -662,7 +663,7 @@ pub mod node_tests {
         let mut ds = D::connect(&storage).await;
 
         // Set up a mock VID scheme to use for generating test data.
-        let vid = VidScheme::new(2, 2, 1, test_srs(2)).unwrap();
+        let vid = vid_scheme(2);
 
         // Generate some mock leaves and blocks to insert.
         let mut leaves = vec![LeafQueryData::<MockTypes>::genesis(&TestInstanceState {})];
@@ -853,7 +854,7 @@ pub mod node_tests {
         let mut ds = D::connect(&storage).await;
 
         // Generate some test VID data.
-        let vid = VidScheme::new(2, 2, 1, test_srs(2)).unwrap();
+        let vid = vid_scheme(2);
         let disperse = vid.disperse([]).unwrap();
 
         // Insert test data with VID common and a share.
@@ -907,14 +908,13 @@ pub mod node_tests {
         let commit = block.payload_hash();
 
         // Set up a test VID scheme.
-        let num_nodes = network.num_nodes();
-        let vid = VidScheme::new(num_nodes, num_nodes, 1, test_srs(num_nodes)).unwrap();
+        let vid = vid_scheme(network.num_nodes());
 
         // Get VID common data and verify it.
         tracing::info!("fetching common data");
         let common = { ds.read().await.get_vid_common(height).await.await };
         let common = common.common();
-        VidScheme::is_consistent(&commit, common).unwrap();
+        VidSchemeType::is_consistent(&commit, common).unwrap();
 
         // Collect shares from each node.
         tracing::info!("fetching shares");

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -124,7 +124,6 @@ pub mod availability_tests {
         node::NodeDataSource,
         testing::{
             consensus::{MockNetwork, TestableDataSource},
-            has_vid,
             mocks::{mock_transaction, MockTypes},
             setup_test,
         },
@@ -218,33 +217,31 @@ pub mod availability_tests {
                     .await;
             }
 
-            // Look up the common VID data. Skip the genesis block, as there is no VID for it.
-            if has_vid(i) {
-                tracing::info!("looking up VID common {i} various ways");
-                let common = ds.get_vid_common(block.height() as usize).await.await;
-                assert_eq!(common, ds.get_vid_common(block.hash()).await.await);
-                // Similar to the above, we can't guarantee which index we will get when passively
-                // fetching this data, so only check the index if the data is available locally.
-                if let Ok(res) = ds
+            // Look up the common VID data.
+            tracing::info!("looking up VID common {i} various ways");
+            let common = ds.get_vid_common(block.height() as usize).await.await;
+            assert_eq!(common, ds.get_vid_common(block.hash()).await.await);
+            // Similar to the above, we can't guarantee which index we will get when passively
+            // fetching this data, so only check the index if the data is available locally.
+            if let Ok(res) = ds
+                .get_vid_common(BlockId::PayloadHash(block.payload_hash()))
+                .await
+                .try_resolve()
+            {
+                if *ix == i as u64 {
+                    assert_eq!(res, common);
+                }
+            } else {
+                tracing::warn!(
+                    "skipping VID common index check for missing data {:?}",
+                    block.header()
+                );
+                // At least check that _some_ data can be fetched.
+                let res = ds
                     .get_vid_common(BlockId::PayloadHash(block.payload_hash()))
                     .await
-                    .try_resolve()
-                {
-                    if *ix == i as u64 {
-                        assert_eq!(res, common);
-                    }
-                } else {
-                    tracing::warn!(
-                        "skipping VID common index check for missing data {:?}",
-                        block.header()
-                    );
-                    // At least check that _some_ data can be fetched.
-                    let res = ds
-                        .get_vid_common(BlockId::PayloadHash(block.payload_hash()))
-                        .await
-                        .await;
-                    assert_eq!(res.payload_hash(), common.payload_hash());
-                }
+                    .await;
+                assert_eq!(res.payload_hash(), common.payload_hash());
             }
 
             for (j, txn) in block.enumerate() {
@@ -400,14 +397,10 @@ pub mod availability_tests {
             tracing::info!(i, "check entries");
             let leaf = leaves.next().await.unwrap().await;
             let block = blocks.next().await.unwrap().await;
-            let common = vid_common.next().await.unwrap();
+            let common = vid_common.next().await.unwrap().await;
             assert_eq!(leaf.height(), i);
             assert_eq!(block.height(), i);
-            if has_vid(i as usize) {
-                assert_eq!(common.await, ds.get_vid_common(i as usize).await.await);
-            } else {
-                common.try_resolve().unwrap_err();
-            }
+            assert_eq!(common, ds.get_vid_common(i as usize).await.await);
         }
 
         if range.end_bound() == Bound::Unbounded {
@@ -565,7 +558,7 @@ pub mod node_tests {
         testing::{
             consensus::{MockNetwork, TestableDataSource},
             mocks::{mock_transaction, MockPayload, MockTypes},
-            setup_test, FIRST_VID_VIEW,
+            setup_test,
         },
         VidShare,
     };
@@ -836,15 +829,8 @@ pub mod node_tests {
 
         network.start().await;
 
-        // Check VID shares for a few blocks. We skip the genesis leaf as there is no VID for the
-        // genesis block.
-        let mut leaves = {
-            ds.read()
-                .await
-                .subscribe_leaves(FIRST_VID_VIEW)
-                .await
-                .take(2)
-        };
+        // Check VID shares for a few blocks.
+        let mut leaves = { ds.read().await.subscribe_leaves(0).await.take(3) };
         while let Some(leaf) = leaves.next().await {
             tracing::info!("got leaf {}", leaf.height());
             let ds = ds.read().await;
@@ -870,10 +856,8 @@ pub mod node_tests {
         let vid = VidScheme::new(2, 2, 1, test_srs(2)).unwrap();
         let disperse = vid.disperse([]).unwrap();
 
-        // Insert test data with VID common and a share. We use height `FIRST_VID_VIEW` to avoid
-        // confusing the data source, which assumes VID cannot exist at lower heights.
-        let mut leaf = LeafQueryData::<MockTypes>::genesis(&TestInstanceState {});
-        leaf.leaf.block_header.block_number = FIRST_VID_VIEW as u64;
+        // Insert test data with VID common and a share.
+        let leaf = LeafQueryData::<MockTypes>::genesis(&TestInstanceState {});
         let common = VidCommonQueryData::new(leaf.header().clone(), disperse.common);
         ds.insert_leaf(leaf).await.unwrap();
         ds.insert_vid(common.clone(), Some(disperse.shares[0].clone()))
@@ -881,21 +865,15 @@ pub mod node_tests {
             .unwrap();
         ds.commit().await.unwrap();
 
-        assert_eq!(ds.get_vid_common(FIRST_VID_VIEW).await.await, common);
-        assert_eq!(
-            ds.vid_share(FIRST_VID_VIEW).await.unwrap(),
-            disperse.shares[0]
-        );
+        assert_eq!(ds.get_vid_common(0).await.await, common);
+        assert_eq!(ds.vid_share(0).await.unwrap(), disperse.shares[0]);
 
         // Re-insert the common data, without a share. This should not overwrite the share we
         // already have.
         ds.insert_vid(common.clone(), None).await.unwrap();
         ds.commit().await.unwrap();
-        assert_eq!(ds.get_vid_common(FIRST_VID_VIEW).await.await, common);
-        assert_eq!(
-            ds.vid_share(FIRST_VID_VIEW).await.unwrap(),
-            disperse.shares[0]
-        );
+        assert_eq!(ds.get_vid_common(0).await.await, common);
+        assert_eq!(ds.vid_share(0).await.unwrap(), disperse.shares[0]);
     }
 
     // This test is currently ignored, as all nodes are temporarily storing the same share, so

--- a/src/data_source/fetching/vid.rs
+++ b/src/data_source/fetching/vid.rs
@@ -47,11 +47,7 @@ where
     Types: NodeType,
 {
     fn might_exist(self, block_height: usize) -> bool {
-        if let BlockId::Number(n) = self.0 {
-            n > 0 && n < block_height
-        } else {
-            true
-        }
+        self.0.might_exist(block_height)
     }
 }
 

--- a/src/data_source/sql.rs
+++ b/src/data_source/sql.rs
@@ -419,7 +419,8 @@ mod test {
         testing::{consensus::DataSourceLifeCycle, mocks::MockTypes, setup_test},
     };
     use hotshot_example_types::state_types::TestInstanceState;
-    use hotshot_types::data::{test_srs, VidScheme, VidSchemeTrait};
+    use hotshot_types::vid::vid_scheme;
+    use jf_primitives::vid::VidScheme;
 
     type D = SqlDataSource<MockTypes, NoFetching>;
 
@@ -433,8 +434,7 @@ mod test {
         let mut ds = <D as DataSourceLifeCycle>::connect(&storage).await;
 
         // Generate some test VID data.
-        let vid = VidScheme::new(2, 2, 1, test_srs(2)).unwrap();
-        let disperse = vid.disperse([]).unwrap();
+        let disperse = vid_scheme(2).disperse([]).unwrap();
 
         // Insert test data with VID common but no share.
         let leaf = LeafQueryData::<MockTypes>::genesis(&TestInstanceState {});

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -26,13 +26,14 @@ use crate::{
     },
     data_source::VersionedDataSource,
     node::{NodeDataSource, SyncStatus},
-    Header, MissingSnafu, NotFoundSnafu, Payload, QueryResult, SignatureKey, VidShare,
+    Header, MissingSnafu, NotFoundSnafu, Payload, QueryResult, SignatureKey, VidCommitment,
+    VidShare,
 };
 use async_trait::async_trait;
 use atomic_store::{AtomicStore, AtomicStoreLoader, PersistenceError};
 use commit::Committable;
 use futures::stream::{self, StreamExt, TryStreamExt};
-use hotshot_types::{data::VidCommitment, traits::node_implementation::NodeType};
+use hotshot_types::traits::node_implementation::NodeType;
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::OptionExt;
 use std::collections::hash_map::{Entry, HashMap};

--- a/src/fetching/provider/query_service.rs
+++ b/src/fetching/provider/query_service.rs
@@ -133,7 +133,7 @@ mod test {
         testing::{
             consensus::{MockDataSource, MockNetwork},
             mocks::{mock_transaction, MockTypes},
-            setup_test, sleep, FIRST_VID_VIEW,
+            setup_test, sleep,
         },
     };
     use async_std::task::spawn;
@@ -524,7 +524,7 @@ mod test {
         // Subscribe to objects from the future.
         let blocks = data_source.subscribe_blocks(0).await;
         let leaves = data_source.subscribe_leaves(0).await;
-        let common = data_source.subscribe_vid_common(FIRST_VID_VIEW).await;
+        let common = data_source.subscribe_vid_common(0).await;
 
         // Wait for a few blocks to be finalized.
         let finalized_leaves = { network.data_source().read().await.subscribe_leaves(0).await };
@@ -541,17 +541,12 @@ mod test {
         // Check the subscriptions.
         let blocks = blocks.take(5).collect::<Vec<_>>().await;
         let leaves = leaves.take(5).collect::<Vec<_>>().await;
-        let common = common.take(5 - FIRST_VID_VIEW).collect::<Vec<_>>().await;
+        let common = common.take(5).collect::<Vec<_>>().await;
         for i in 0..5 {
             tracing::info!("checking block {i}");
             assert_eq!(leaves[i], finalized_leaves[i]);
             assert_eq!(blocks[i].header(), finalized_leaves[i].header());
-            if i >= FIRST_VID_VIEW {
-                assert_eq!(
-                    common[i - FIRST_VID_VIEW],
-                    data_source.get_vid_common(i).await.await
-                );
-            }
+            assert_eq!(common[i], data_source.get_vid_common(i).await.await);
         }
     }
 

--- a/src/fetching/request.rs
+++ b/src/fetching/request.rs
@@ -12,9 +12,9 @@
 
 //! Requests for fetching resources.
 
-use crate::{availability::LeafQueryData, Payload, VidCommon};
+use crate::{availability::LeafQueryData, Payload, VidCommitment, VidCommon};
 use derive_more::{From, Into};
-use hotshot_types::{data::VidCommitment, traits::node_implementation::NodeType};
+use hotshot_types::traits::node_implementation::NodeType;
 
 use std::fmt::Debug;
 use std::hash::Hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,18 +423,18 @@ use async_std::{
 };
 use futures::StreamExt;
 use hotshot::types::SystemContextHandle;
-use hotshot_types::{
-    data::{VidScheme, VidSchemeTrait},
-    traits::{
-        node_implementation::{NodeImplementation, NodeType},
-        BlockPayload,
-    },
+use hotshot_types::traits::{
+    node_implementation::{NodeImplementation, NodeType},
+    BlockPayload,
 };
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use tide_disco::{App, StatusCode};
 
-pub use hotshot_types::data::Leaf;
+pub use hotshot_types::{
+    data::Leaf,
+    vid::{VidCommitment, VidCommon, VidShare},
+};
 
 pub type Payload<Types> = <Types as NodeType>::BlockPayload;
 pub type Header<Types> = <Types as NodeType>::BlockHeader;
@@ -442,8 +442,6 @@ pub type Metadata<Types> = <Payload<Types> as BlockPayload>::Metadata;
 /// Item within a [`Payload`].
 pub type Transaction<Types> = <Payload<Types> as BlockPayload>::Transaction;
 pub type SignatureKey<Types> = <Types as NodeType>::SignatureKey;
-pub type VidCommon = <VidScheme as VidSchemeTrait>::Common;
-pub type VidShare = <VidScheme as VidSchemeTrait>::Share;
 
 #[derive(Clone, Debug, Snafu, Deserialize, Serialize)]
 #[snafu(visibility(pub))]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -32,14 +32,3 @@ pub fn setup_test() {
         backtrace_on_stack_overflow::enable();
     }
 }
-
-/// Whether VID is expected for the given block height.
-///
-/// VID is skipped in HotShot for the genesis block.
-pub fn has_vid(height: usize) -> bool {
-    height >= FIRST_VID_VIEW
-}
-
-// Currently, HotShot also skips VID for view 1 (block 1). This should be fixed soon, but in the
-// meantime, we need to skip VID tests for this block.
-pub const FIRST_VID_VIEW: usize = 2;


### PR DESCRIPTION
* Handle views 0 and 1, so we no longer have the edge case where VID data is missing for these views
* Fix tests accordingly
* When fetching VID payload or common data from another query service, verify results against expected commitment
* Use standardized VID constructor from HotShot

Closes #355 