### PR TITLE
Cleanup docker containers on termination

### DIFF
--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -1450,6 +1450,7 @@ pub mod testing {
 
             let output = Command::new("docker")
                 .arg("run")
+                .arg("--rm")
                 .arg("-d")
                 .args(["-p", &format!("{port}:5432")])
                 .args(["-e", "POSTGRES_PASSWORD=password"])
@@ -1520,7 +1521,7 @@ pub mod testing {
     impl Drop for TmpDb {
         fn drop(&mut self) {
             let output = Command::new("docker")
-                .args(["kill", self.container_id.as_str()])
+                .args(["stop", self.container_id.as_str()])
                 .output()
                 .unwrap();
             if !output.status.success() {

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -1531,18 +1531,6 @@ pub mod testing {
                     str::from_utf8(&output.stderr).unwrap()
                 );
             }
-
-            let output = Command::new("docker")
-                .args(["rm", self.container_id.as_str()])
-                .output()
-                .unwrap();
-            if !output.status.success() {
-                tracing::error!(
-                    "error removing postgres docker {}: {}",
-                    self.container_id,
-                    str::from_utf8(&output.stderr).unwrap()
-                );
-            }
         }
     }
 }


### PR DESCRIPTION
The `--rm` switch tells docker to cleanup containers on termination. Without this an explicit `remove` is required after `stop` to clean up the container and a `prune` to remove arbitrary volumes left behind. While these are not difficult actions to perform, we are often unaware that we need to do them.

I've also changed `kill` to `stop` because `stop` in the drop fn because `stop` attempts to shutdown the container gracefully.