### PR TITLE
Implement timestamp queries; drop proposer queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "hotshot-constants"
 version = "0.3.3"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "serde",
 ]
@@ -2895,7 +2895,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -2919,6 +2919,7 @@ dependencies = [
  "sha2 0.10.8",
  "sha3",
  "snafu",
+ "time 0.3.34",
  "tokio",
  "tracing",
 ]
@@ -2926,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -3001,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3014,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-broadcast",
  "async-compatibility-layer",
@@ -3042,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3089,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "bincode",
  "hotshot-constants",
@@ -3098,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "hotshot-web-server"
 version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",
@@ -4022,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.20#eeaf829a258c317da0946858b6abb57498493674"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.22#2b3f5b194f7666940247cc1f9cecd02125e7630c"
 dependencies = [
  "async-compatibility-layer",
  "async-lock 2.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -7777,6 +7777,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7881,11 +7887,12 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall",
+ "wasite",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.10"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.20" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.20" }
-hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.20" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.22" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.22" }
+hotshot-utils = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.22" }
 itertools = "0.12.1"
 jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.0" }
 prometheus = "0.13"
@@ -107,7 +107,7 @@ tokio-postgres = { version = "0.7", optional = true, default-features = false, f
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.20", optional = true }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.22", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -127,7 +127,7 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 [dev-dependencies]
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 generic-array = "0.14"
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.20" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.22" }
 portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"

--- a/api/availability.toml
+++ b/api/availability.toml
@@ -104,7 +104,6 @@ Get the headers based on their position in the ledger,
 the headers are taken starting from the given :from up until the given :until.
 """
 
-
 [route.stream_headers]
 PATH = ["stream/headers/:height"]
 METHOD = "SOCKET"

--- a/api/node.toml
+++ b/api/node.toml
@@ -19,10 +19,10 @@ A node's view of a HotShot chain
 The node API provides a subjective view of the HotShot blockchain, from the perspective of one
 particular node. It provides access to information that the availability API does not, because this
 information depends on the perspective of the node observing it, and may be subject to eventual
-consistency. For example, `/node/block-height` and `/node/proposals/:proposer_id/count` may both
-return smaller counts than expected, if the node being queried is not fully synced with the entire
-history of the chain. However, the node will _eventually_ sync and return the expected counts. See
-`/node/sync-status` for information on how in or out of sync the node currently is.
+consistency. For example, `/node/block-height` may return smaller counts than expected, if the node
+being queried is not fully synced with the entire history of the chain. However, the node will
+_eventually_ sync and return the expected counts. See `/node/sync-status` for information on how in
+or out of sync the node currently is.
 """
 
 [route.block_height]
@@ -31,44 +31,6 @@ DOC = """
 The current height of the chain, as observed by this node.
 
 Returns an integer.
-"""
-
-[route.count_proposals]
-PATH = ["proposals/:proposer_id/count"]
-":proposer_id" = "TaggedBase64"
-DOC = """
-Get the number of committed blocks proposed by `proposer_id`, known to this node.
-
-Warning: count may be low if data is currently being indexed (see `sync-status`).
-
-Returns an integer.
-"""
-
-[route.get_proposals]
-PATH = ["proposals/:proposer_id", "proposals/:proposer_id/limit/:count"]
-":proposer_id" = "TaggedBase64"
-":count" = "Integer"
-DOC = """
-Get the leaf data of `:count` leaves from the proposer with `:proposer_id`, starting backwards from
-the most recent leaf from this proposer. If the proposer has proposed fewer leaves than `:count`,
-return all the leaves from the proposer.
-
-Warning: response may be incomplete if data is currently being indexed (see `sync-status`).
-
-Returns a list of
-
-```
-{
-    "leaf": {
-        "view_number": integer,
-        "justify_qc": QC,
-        "parent_commitment": TaggedBase64,
-        "block_header": app-specific header type,
-        "proposer_id": TaggedBase64,
-    },
-    "qc": QC,
-}
-```
 """
 
 [route.count_transactions]

--- a/api/node.toml
+++ b/api/node.toml
@@ -118,3 +118,41 @@ Returns
 }
 ```
 """
+
+[route.get_header_window]
+PATH = [
+    "header/window/:start/:end",
+    "header/window/from/:height/:end",
+    "header/window/from/hash/:hash/:end",
+]
+":start" = "Integer"
+":end" = "Integer"
+":height" = "Integer"
+":hash" = "TaggedBase64"
+DOC = """
+Get block headers in a time window.
+
+Returns all available headers, in order, whose timestamps fall between `:start` (inclusive) and
+`:end` (exclusive), or between the block indicated by `:height` or `:hash` (inclusive) and `:end`
+(exclusive). The response also includes one block before the desired window (unless the window
+includes the genesis block) and one block after the window. This proves to the client that the
+server has not omitted any blocks whose timestamps fall within the desired window.
+
+It is possible that not all blocks in the desired window are available when this endpoint is called.
+In that case, whichever blocks are available are included in the response, and `next` is `null` to
+indicate that the response is not complete. The client can then use one of the `/from/` forms of
+this endpoint to fetch the remaining blocks from where the first response left off, once they become
+available. If no blocks are available, not even `prev`, this endpoint will return an error.
+
+Returns
+
+```json
+{
+    "window": ["Header"],
+    "prev": "Header", // nullable
+    "next": "Header"  // nullable
+}
+```
+
+All timestamps are denominated in an integer number of seconds.
+"""

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,8 @@
         RUST_BACKTRACE = 1;
         RUST_LOG = "info";
         RUSTFLAGS=" --cfg async_executor_impl=\"async-std\" --cfg async_channel_impl=\"async-std\"";
+        # Use a distinct target dir for builds from within nix shells.
+        CARGO_TARGET_DIR = "target/nix";
       in {
       	checks = {
           pre-commit-check = pre-commit-hooks.lib.${system}.run {
@@ -178,7 +180,7 @@
               rustToolchain
             ] ++ myPython ++ rustDeps;
 
-          inherit RUST_SRC_PATH RUST_BACKTRACE RUST_LOG RUSTFLAGS;
+          inherit RUST_SRC_PATH RUST_BACKTRACE RUST_LOG RUSTFLAGS CARGO_TARGET_DIR;
         };
         devShells = {
           perfShell = pkgs.mkShell {
@@ -186,7 +188,7 @@
             buildInputs = with pkgs;
               [ nixWithFlakes cargo-llvm-cov rustToolchain ] ++ rustDeps;
 
-            inherit RUST_SRC_PATH RUST_BACKTRACE RUST_LOG RUSTFLAGS;
+            inherit RUST_SRC_PATH RUST_BACKTRACE RUST_LOG RUSTFLAGS CARGO_TARGET_DIR;
           };
         };
       });

--- a/migrations/V10__init_schema.sql
+++ b/migrations/V10__init_schema.sql
@@ -34,7 +34,6 @@ CREATE TABLE leaf
 (
     height     BIGINT  PRIMARY KEY REFERENCES header (height) ON DELETE CASCADE,
     hash       VARCHAR NOT NULL UNIQUE,
-    proposer   VARCHAR NOT NULL,
     block_hash VARCHAR NOT NULL REFERENCES header (hash) ON DELETE CASCADE,
 
     -- For convenience, we store the entire leaf and justifying QC as JSON blobs. There is a bit of
@@ -47,7 +46,6 @@ CREATE TABLE leaf
     leaf JSONB NOT NULL,
     qc   JSONB NOT NULL
 );
-CREATE INDEX leaf_proposer ON leaf (proposer);
 
 CREATE TABLE transaction
 (

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -487,6 +487,7 @@ mod test {
             mocks::{mock_transaction, MockHeader, MockPayload, MockTypes},
             setup_test,
         },
+        types::HeightIndexed,
         Error, Header,
     };
     use async_std::{sync::RwLock, task::spawn};

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -10,7 +10,9 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::{Header, Metadata, Payload, SignatureKey, Transaction, VidCommon};
+use crate::{
+    types::HeightIndexed, Header, Metadata, Payload, SignatureKey, Transaction, VidCommon,
+};
 use commit::{Commitment, Committable};
 use hotshot_types::{
     data::Leaf,
@@ -240,10 +242,6 @@ impl<Types: NodeType> LeafQueryData<Types> {
         &self.leaf.block_header
     }
 
-    pub fn height(&self) -> u64 {
-        self.header().block_number()
-    }
-
     pub fn hash(&self) -> LeafHash<Types> {
         self.leaf.commit()
     }
@@ -258,6 +256,12 @@ impl<Types: NodeType> LeafQueryData<Types> {
 
     pub fn proposer(&self) -> SignatureKey<Types> {
         self.leaf.get_proposer_id()
+    }
+}
+
+impl<Types: NodeType> HeightIndexed for LeafQueryData<Types> {
+    fn height(&self) -> u64 {
+        self.header().block_number()
     }
 }
 
@@ -315,10 +319,6 @@ impl<Types: NodeType> BlockQueryData<Types> {
         self.hash
     }
 
-    pub fn height(&self) -> u64 {
-        self.header.block_number()
-    }
-
     pub fn size(&self) -> u64 {
         self.size
     }
@@ -369,6 +369,12 @@ where
     }
 }
 
+impl<Types: NodeType> HeightIndexed for BlockQueryData<Types> {
+    fn height(&self) -> u64 {
+        self.header.block_number()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(bound = "")]
 pub struct PayloadQueryData<Types: NodeType> {
@@ -399,10 +405,6 @@ impl<Types: NodeType> PayloadQueryData<Types> {
         BlockQueryData::genesis(instance_state).into()
     }
 
-    pub fn height(&self) -> u64 {
-        self.height
-    }
-
     pub fn hash(&self) -> VidCommitment {
         self.hash
     }
@@ -417,6 +419,12 @@ impl<Types: NodeType> PayloadQueryData<Types> {
 
     pub fn data(&self) -> &Payload<Types> {
         &self.data
+    }
+}
+
+impl<Types: NodeType> HeightIndexed for PayloadQueryData<Types> {
+    fn height(&self) -> u64 {
+        self.height
     }
 }
 
@@ -450,10 +458,6 @@ impl<Types: NodeType> VidCommonQueryData<Types> {
         Self::new(leaf.block_header, disperse.common)
     }
 
-    pub fn height(&self) -> u64 {
-        self.height
-    }
-
     pub fn block_hash(&self) -> BlockHash<Types> {
         self.block_hash
     }
@@ -464,6 +468,12 @@ impl<Types: NodeType> VidCommonQueryData<Types> {
 
     pub fn common(&self) -> &VidCommon {
         &self.common
+    }
+}
+
+impl<Types: NodeType> HeightIndexed for VidCommonQueryData<Types> {
+    fn height(&self) -> u64 {
+        self.height
     }
 }
 
@@ -528,10 +538,6 @@ impl<Types: NodeType> BlockSummaryQueryData<Types> {
         self.hash
     }
 
-    pub fn height(&self) -> u64 {
-        self.header.block_number()
-    }
-
     pub fn size(&self) -> u64 {
         self.size
     }
@@ -542,6 +548,12 @@ impl<Types: NodeType> BlockSummaryQueryData<Types> {
 
     pub fn proposer(&self) -> SignatureKey<Types> {
         self.proposer_id.clone()
+    }
+}
+
+impl<Types: NodeType> HeightIndexed for BlockSummaryQueryData<Types> {
+    fn height(&self) -> u64 {
+        self.header.block_number()
     }
 }
 

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -10,9 +10,7 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    types::HeightIndexed, Header, Metadata, Payload, SignatureKey, Transaction, VidCommon,
-};
+use crate::{types::HeightIndexed, Header, Metadata, Payload, Transaction, VidCommon};
 use commit::{Commitment, Committable};
 use hotshot_types::{
     data::Leaf,
@@ -253,10 +251,6 @@ impl<Types: NodeType> LeafQueryData<Types> {
     pub fn payload_hash(&self) -> VidCommitment {
         self.header().payload_commitment()
     }
-
-    pub fn proposer(&self) -> SignatureKey<Types> {
-        self.leaf.get_proposer_id()
-    }
 }
 
 impl<Types: NodeType> HeightIndexed for LeafQueryData<Types> {
@@ -273,7 +267,6 @@ pub struct BlockQueryData<Types: NodeType> {
     pub(crate) hash: BlockHash<Types>,
     pub(crate) size: u64,
     pub(crate) num_transactions: u64,
-    pub(crate) proposer_id: SignatureKey<Types>,
 }
 
 impl<Types: NodeType> BlockQueryData<Types> {
@@ -285,7 +278,6 @@ impl<Types: NodeType> BlockQueryData<Types> {
             hash: header.commit(),
             size: payload_size::<Types>(&payload),
             num_transactions: payload.len(header.metadata()) as u64,
-            proposer_id: get_proposer::<Types>(header.clone()),
             header,
             payload,
         }
@@ -325,10 +317,6 @@ impl<Types: NodeType> BlockQueryData<Types> {
 
     pub fn num_transactions(&self) -> u64 {
         self.num_transactions
-    }
-
-    pub fn proposer(&self) -> SignatureKey<Types> {
-        self.proposer_id.clone()
     }
 }
 
@@ -525,7 +513,6 @@ pub struct BlockSummaryQueryData<Types: NodeType> {
     pub(crate) hash: BlockHash<Types>,
     pub(crate) size: u64,
     pub(crate) num_transactions: u64,
-    pub(crate) proposer_id: SignatureKey<Types>,
 }
 
 // Add some basic getters to the BlockSummaryQueryData type.
@@ -545,27 +532,12 @@ impl<Types: NodeType> BlockSummaryQueryData<Types> {
     pub fn num_transactions(&self) -> u64 {
         self.num_transactions
     }
-
-    pub fn proposer(&self) -> SignatureKey<Types> {
-        self.proposer_id.clone()
-    }
 }
 
 impl<Types: NodeType> HeightIndexed for BlockSummaryQueryData<Types> {
     fn height(&self) -> u64 {
         self.header.block_number()
     }
-}
-
-// Get the Proposer from the given header.  At the moment the proposer cannot
-// be determined from the header, however it is intended to in the future.
-// For now we will just generate one with dummy data.
-// TODO update this function to retrieve the proposer from the Header type once
-//      the Header type has been updated to include the proposer.
-pub(crate) fn get_proposer<Types: NodeType>(_header: Header<Types>) -> SignatureKey<Types> {
-    use hotshot::types::SignatureKey;
-    let (key, _) = SignatureKey::generated_from_seed_indexed([0; 32], 0);
-    key
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -592,7 +564,6 @@ where
             hash: value.hash,
             size: value.size,
             num_transactions: value.num_transactions,
-            proposer_id: value.proposer_id,
         }
     }
 }

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -127,6 +127,7 @@ pub mod availability_tests {
             mocks::{mock_transaction, MockTypes},
             setup_test,
         },
+        types::HeightIndexed,
     };
     use async_std::sync::RwLock;
     use commit::Committable;
@@ -553,15 +554,17 @@ pub mod persistence_tests {
 pub mod node_tests {
     use super::test_helpers::*;
     use crate::{
-        availability::{BlockQueryData, LeafQueryData, VidCommonQueryData},
-        node::{BlockId, SyncStatus},
+        availability::{BlockQueryData, LeafQueryData, QueryableHeader, VidCommonQueryData},
+        node::{BlockId, SyncStatus, TimeWindowQueryData, WindowStart},
         testing::{
             consensus::{MockNetwork, TestableDataSource},
             mocks::{mock_transaction, MockPayload, MockTypes},
             setup_test,
         },
-        VidShare,
+        types::HeightIndexed,
+        Header, VidShare,
     };
+    use commit::Committable;
     use futures::{future::join_all, stream::StreamExt};
     use hotshot_example_types::{
         block_types::{TestBlockHeader, TestBlockPayload},
@@ -807,6 +810,7 @@ pub mod node_tests {
             let payload_commitment = vid_commitment(&encoded, 1);
             let header = TestBlockHeader {
                 block_number: i,
+                timestamp: i,
                 payload_commitment,
             };
 
@@ -938,6 +942,159 @@ pub mod node_tests {
         let recovered = MockPayload::from_bytes(bytes.into_iter(), &());
         assert_eq!(recovered, *block.payload());
         assert_eq!(recovered.transactions, vec![txn]);
+    }
+
+    #[async_std::test]
+    pub async fn test_timestamp_window<D: TestableDataSource>() {
+        setup_test();
+
+        let mut network = MockNetwork::<D>::init().await;
+        let ds = network.data_source();
+
+        network.start().await;
+
+        // Wait for blocks with at least three different timestamps to be sequenced. This lets us
+        // test all the edge cases.
+        let mut leaves = { ds.read().await.subscribe_leaves(0).await };
+        // `test_blocks` is a list of lists of headers with the same timestamp. The flattened list
+        // of headers is contiguous.
+        let mut test_blocks: Vec<Vec<Header<MockTypes>>> = vec![];
+        while test_blocks.len() < 3 {
+            // Wait for the next block to be sequenced.
+            let leaf = leaves.next().await.unwrap();
+            let header = leaf.header().clone();
+            if let Some(last_timestamp) = test_blocks.last_mut() {
+                if last_timestamp[0].timestamp() == header.timestamp() {
+                    last_timestamp.push(header);
+                } else {
+                    test_blocks.push(vec![header]);
+                }
+            } else {
+                test_blocks.push(vec![header]);
+            }
+        }
+        tracing::info!("blocks for testing: {test_blocks:#?}");
+
+        // Define invariants that every response should satisfy.
+        let check_invariants =
+            |res: &TimeWindowQueryData<Header<MockTypes>>, start, end, check_prev| {
+                let mut prev = res.prev.as_ref();
+                if let Some(prev) = prev {
+                    if check_prev {
+                        assert!(prev.timestamp() < start);
+                    }
+                } else {
+                    // `prev` can only be `None` if the first block in the window is the genesis
+                    // block.
+                    assert_eq!(res.from().unwrap(), 0);
+                };
+                for header in &res.window {
+                    assert!(start <= header.timestamp());
+                    assert!(header.timestamp() < end);
+                    if let Some(prev) = prev {
+                        assert!(prev.timestamp() <= header.timestamp());
+                    }
+                    prev = Some(header);
+                }
+                if let Some(next) = &res.next {
+                    assert!(next.timestamp() >= end);
+                    // If there is a `next`, there must be at least one previous block (either `prev`
+                    // itself or the last block if the window is nonempty), so we can `unwrap` here.
+                    assert!(next.timestamp() >= prev.unwrap().timestamp());
+                }
+            };
+
+        let get_window = |start, end| {
+            let ds = ds.clone();
+            async move {
+                let window = ds
+                    .read()
+                    .await
+                    .get_header_window(WindowStart::Time(start), end)
+                    .await
+                    .unwrap();
+                tracing::info!("window for timestamp range {start}-{end}: {window:#?}");
+                check_invariants(&window, start, end, true);
+                window
+            }
+        };
+
+        // Case 0: happy path. All blocks are available, including prev and next.
+        let start = test_blocks[1][0].timestamp();
+        let end = start + 1;
+        let res = get_window(start, end).await;
+        assert_eq!(res.prev.unwrap(), *test_blocks[0].last().unwrap());
+        assert_eq!(res.window, test_blocks[1]);
+        assert_eq!(res.next.unwrap(), test_blocks[2][0]);
+
+        // Case 1: no `prev`, start of window is before genesis.
+        let start = 0;
+        let end = test_blocks[0][0].timestamp() + 1;
+        let res = get_window(start, end).await;
+        assert_eq!(res.prev, None);
+        assert_eq!(res.window, test_blocks[0]);
+        assert_eq!(res.next.unwrap(), test_blocks[1][0]);
+
+        // Case 2: no `next`, end of window is after the most recently sequenced block.
+        let start = test_blocks[2][0].timestamp();
+        let end = i64::MAX as u64;
+        let res = get_window(start, end).await;
+        assert_eq!(res.prev.unwrap(), *test_blocks[1].last().unwrap());
+        // There may have been more blocks sequenced since we grabbed `test_blocks`, so just check
+        // that the prefix of the window is correct.
+        assert_eq!(res.window[..test_blocks[2].len()], test_blocks[2]);
+        assert_eq!(res.next, None);
+        // Fetch more blocks using the `from` form of the endpoint. Start from the last block we had
+        // previously (ie fetch a slightly overlapping window) to ensure there is at least one block
+        // in the new window.
+        let from = test_blocks.iter().flatten().count() - 1;
+        let more = {
+            ds.read()
+                .await
+                .get_header_window(WindowStart::Height(from as u64), end)
+                .await
+                .unwrap()
+        };
+        check_invariants(&more, start, end, false);
+        assert_eq!(
+            more.prev.as_ref().unwrap(),
+            test_blocks.iter().flatten().nth(from - 1).unwrap()
+        );
+        assert_eq!(
+            more.window[..res.window.len() - test_blocks[2].len() + 1],
+            res.window[test_blocks[2].len() - 1..]
+        );
+        assert_eq!(res.next, None);
+        // We should get the same result whether we query by block height or hash.
+        let more2 = {
+            ds.read()
+                .await
+                .get_header_window(test_blocks[2].last().unwrap().commit(), end)
+                .await
+                .unwrap()
+        };
+        check_invariants(&more2, start, end, false);
+        assert_eq!(more2.from().unwrap(), more.from().unwrap());
+        assert_eq!(more2.prev, more.prev);
+        assert_eq!(more2.next, more.next);
+        assert_eq!(more2.window[..more.window.len()], more.window);
+
+        // Case 3: the window is empty.
+        let start = test_blocks[1][0].timestamp();
+        let end = start;
+        let res = get_window(start, end).await;
+        assert_eq!(res.prev.unwrap(), *test_blocks[0].last().unwrap());
+        assert_eq!(res.next.unwrap(), test_blocks[1][0]);
+        assert_eq!(res.window, vec![]);
+
+        // Case 5: no relevant blocks are available yet.
+        {
+            ds.read()
+                .await
+                .get_header_window(WindowStart::Time((i64::MAX - 1) as u64), i64::MAX as u64)
+                .await
+                .unwrap_err();
+        }
     }
 }
 

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -20,7 +20,7 @@ use crate::{
     metrics::PrometheusMetrics,
     node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
     status::StatusDataSource,
-    Header, Payload, QueryResult, SignatureKey, VidShare,
+    Header, Payload, QueryResult, VidShare,
 };
 use async_trait::async_trait;
 use hotshot_types::traits::node_implementation::NodeType;
@@ -236,16 +236,6 @@ where
 {
     async fn block_height(&self) -> QueryResult<usize> {
         self.data_source.block_height().await
-    }
-    async fn get_proposals(
-        &self,
-        proposer: &SignatureKey<Types>,
-        limit: Option<usize>,
-    ) -> QueryResult<Vec<LeafQueryData<Types>>> {
-        self.data_source.get_proposals(proposer, limit).await
-    }
-    async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize> {
-        self.data_source.count_proposals(proposer).await
     }
     async fn count_transactions(&self) -> QueryResult<usize> {
         self.data_source.count_transactions().await

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -18,9 +18,9 @@ use crate::{
         UpdateAvailabilityData, VidCommonQueryData,
     },
     metrics::PrometheusMetrics,
-    node::{NodeDataSource, SyncStatus},
+    node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
     status::StatusDataSource,
-    Payload, QueryResult, SignatureKey, VidShare,
+    Header, Payload, QueryResult, SignatureKey, VidShare,
 };
 use async_trait::async_trait;
 use hotshot_types::traits::node_implementation::NodeType;
@@ -261,6 +261,13 @@ where
     }
     async fn sync_status(&self) -> QueryResult<SyncStatus> {
         self.data_source.sync_status().await
+    }
+    async fn get_header_window(
+        &self,
+        start: impl Into<WindowStart<Types>> + Send + Sync,
+        end: u64,
+    ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
+        self.data_source.get_header_window(start, end).await
     }
 }
 

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -87,7 +87,7 @@ use crate::{
     status::StatusDataSource,
     task::BackgroundTask,
     types::HeightIndexed,
-    Header, Payload, QueryResult, SignatureKey, VidShare,
+    Header, Payload, QueryResult, VidShare,
 };
 use anyhow::Context;
 use async_std::{
@@ -580,18 +580,6 @@ where
 {
     async fn block_height(&self) -> QueryResult<usize> {
         Ok(self.fetcher.storage.read().await.height as usize)
-    }
-
-    async fn get_proposals(
-        &self,
-        proposer: &SignatureKey<Types>,
-        limit: Option<usize>,
-    ) -> QueryResult<Vec<LeafQueryData<Types>>> {
-        self.storage().await.get_proposals(proposer, limit).await
-    }
-
-    async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize> {
-        self.storage().await.count_proposals(proposer).await
     }
 
     async fn count_transactions(&self) -> QueryResult<usize> {

--- a/src/data_source/fetching/block.rs
+++ b/src/data_source/fetching/block.rs
@@ -27,6 +27,7 @@ use crate::{
         request::{self, PayloadRequest},
         Callback,
     },
+    types::HeightIndexed,
     Header, Payload, QueryResult,
 };
 use async_std::sync::{Arc, RwLockReadGuard};
@@ -189,10 +190,6 @@ where
     {
         storage.storage.get_block_range(range).await
     }
-
-    fn height(&self) -> usize {
-        self.height() as usize
-    }
 }
 
 pub(super) fn fetch_block_with_header<Types, S, P>(
@@ -304,10 +301,6 @@ where
         R: RangeBounds<usize> + Send + 'static,
     {
         storage.storage.get_payload_range(range).await
-    }
-
-    fn height(&self) -> usize {
-        self.height() as usize
     }
 }
 

--- a/src/data_source/fetching/leaf.rs
+++ b/src/data_source/fetching/leaf.rs
@@ -20,6 +20,7 @@ use crate::{
     availability::{LeafId, LeafQueryData, QueryablePayload, UpdateAvailabilityData},
     data_source::{storage::AvailabilityStorage, VersionedDataSource},
     fetching::{self, request, Callback},
+    types::HeightIndexed,
     Payload, QueryResult,
 };
 use async_std::sync::{Arc, RwLockReadGuard};
@@ -155,10 +156,6 @@ where
         R: RangeBounds<usize> + Send + 'static,
     {
         storage.storage.get_leaf_range(range).await
-    }
-
-    fn height(&self) -> usize {
-        self.height() as usize
     }
 }
 

--- a/src/data_source/fetching/vid.rs
+++ b/src/data_source/fetching/vid.rs
@@ -20,6 +20,7 @@ use crate::{
     availability::{BlockId, QueryablePayload, UpdateAvailabilityData, VidCommonQueryData},
     data_source::{storage::AvailabilityStorage, VersionedDataSource},
     fetching::{self, request, Callback},
+    types::HeightIndexed,
     Header, Payload, QueryResult, VidCommon,
 };
 use async_std::sync::{Arc, RwLockReadGuard};
@@ -118,10 +119,6 @@ where
         R: RangeBounds<usize> + Send + 'static,
     {
         storage.storage.get_vid_common_range(range).await
-    }
-
-    fn height(&self) -> usize {
-        self.height() as usize
     }
 }
 

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -21,12 +21,13 @@ use crate::{
     availability::{
         data_source::{BlockId, LeafId, UpdateAvailabilityData},
         query_data::{
-            BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadQueryData, QueryablePayload,
-            TransactionHash, TransactionIndex, VidCommonQueryData,
+            BlockHash, BlockQueryData, LeafHash, LeafQueryData, PayloadQueryData, QueryableHeader,
+            QueryablePayload, TransactionHash, TransactionIndex, VidCommonQueryData,
         },
     },
     data_source::VersionedDataSource,
-    node::{NodeDataSource, SyncStatus},
+    node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
+    types::HeightIndexed,
     Header, MissingSnafu, NotFoundSnafu, Payload, QueryResult, SignatureKey, VidCommitment,
     VidShare,
 };
@@ -34,10 +35,13 @@ use async_trait::async_trait;
 use atomic_store::{AtomicStore, AtomicStoreLoader, PersistenceError};
 use commit::Committable;
 use futures::stream::{self, StreamExt, TryStreamExt};
-use hotshot_types::traits::node_implementation::NodeType;
+use hotshot_types::traits::{block_contents::BlockHeader, node_implementation::NodeType};
 use serde::{de::DeserializeOwned, Serialize};
 use snafu::OptionExt;
-use std::collections::hash_map::{Entry, HashMap};
+use std::collections::{
+    hash_map::{Entry, HashMap},
+    BTreeMap,
+};
 use std::convert::Infallible;
 use std::hash::Hash;
 use std::ops::{Bound, RangeBounds};
@@ -58,11 +62,7 @@ where
     index_by_payload_hash: HashMap<VidCommitment, u64>,
     index_by_txn_hash: HashMap<TransactionHash<Types>, (u64, TransactionIndex<Types>)>,
     index_by_proposer_id: HashMap<SignatureKey<Types>, Vec<u64>>,
-    // We have separate indexes for VID than for other data, because of the special case where VID
-    // information does not exist for the genesis block. This means that VID data for blocks that
-    // are duplicates of the genesis block may exist but not be findable through the block indexes.
-    index_vid_by_block_hash: HashMap<BlockHash<Types>, u64>,
-    index_vid_by_payload_hash: HashMap<VidCommitment, u64>,
+    index_by_time: BTreeMap<u64, Vec<u64>>,
     num_transactions: usize,
     payload_size: usize,
     #[debug(skip)]
@@ -90,6 +90,7 @@ impl<Types: NodeType> PruneStorage for FileSystemStorage<Types> where
 impl<Types: NodeType> FileSystemStorage<Types>
 where
     Payload<Types>: QueryablePayload,
+    Header<Types>: QueryableHeader<Types>,
 {
     /// Create a new [FileSystemStorage] with storage at `path`.
     ///
@@ -132,8 +133,7 @@ where
             index_by_payload_hash: Default::default(),
             index_by_txn_hash: Default::default(),
             index_by_proposer_id: Default::default(),
-            index_vid_by_block_hash: Default::default(),
-            index_vid_by_payload_hash: Default::default(),
+            index_by_time: Default::default(),
             num_transactions: 0,
             payload_size: 0,
             top_storage: None,
@@ -165,6 +165,7 @@ where
         let mut index_by_proposer_id = HashMap::new();
         let mut index_by_block_hash = HashMap::new();
         let mut index_by_payload_hash = HashMap::new();
+        let mut index_by_time = BTreeMap::<u64, Vec<u64>>::new();
         let index_by_leaf_hash = leaf_storage
             .iter()
             .flatten()
@@ -179,6 +180,10 @@ where
                     leaf.payload_hash(),
                     leaf.height(),
                 );
+                index_by_time
+                    .entry(leaf.header().timestamp())
+                    .or_default()
+                    .push(leaf.height());
                 (leaf.hash(), leaf.height())
             })
             .collect();
@@ -196,29 +201,13 @@ where
             }
         }
 
-        let mut index_vid_by_block_hash = HashMap::new();
-        let mut index_vid_by_payload_hash = HashMap::new();
-        for (common, _) in vid_storage.iter().flatten() {
-            update_index_by_hash(
-                &mut index_vid_by_block_hash,
-                common.block_hash(),
-                common.height(),
-            );
-            update_index_by_hash(
-                &mut index_vid_by_payload_hash,
-                common.payload_hash(),
-                common.height(),
-            );
-        }
-
         Ok(Self {
             index_by_leaf_hash,
             index_by_block_hash,
             index_by_payload_hash,
             index_by_txn_hash,
             index_by_proposer_id,
-            index_vid_by_block_hash,
-            index_vid_by_payload_hash,
+            index_by_time,
             num_transactions,
             payload_size,
             leaf_storage,
@@ -248,20 +237,6 @@ where
             BlockId::PayloadHash(h) => {
                 Ok(*self.index_by_payload_hash.get(&h).context(NotFoundSnafu)? as usize)
             }
-        }
-    }
-
-    fn get_vid_index(&self, id: BlockId<Types>) -> QueryResult<usize> {
-        match id {
-            BlockId::Number(n) => Ok(n),
-            BlockId::Hash(h) => Ok(*self
-                .index_vid_by_block_hash
-                .get(&h)
-                .context(NotFoundSnafu)? as usize),
-            BlockId::PayloadHash(h) => Ok(*self
-                .index_vid_by_payload_hash
-                .get(&h)
-                .context(NotFoundSnafu)? as usize),
         }
     }
 }
@@ -335,6 +310,7 @@ where
 impl<Types: NodeType> AvailabilityStorage<Types> for FileSystemStorage<Types>
 where
     Payload<Types>: QueryablePayload,
+    Header<Types>: QueryableHeader<Types>,
 {
     async fn get_leaf(&self, id: LeafId<Types>) -> QueryResult<LeafQueryData<Types>> {
         let n = match id {
@@ -368,7 +344,7 @@ where
         Ok(self
             .vid_storage
             .iter()
-            .nth(self.get_vid_index(id)?)
+            .nth(self.get_block_index(id)?)
             .context(NotFoundSnafu)?
             .context(MissingSnafu)?
             .0)
@@ -432,6 +408,7 @@ where
 impl<Types: NodeType> UpdateAvailabilityData<Types> for FileSystemStorage<Types>
 where
     Payload<Types>: QueryablePayload,
+    Header<Types>: QueryableHeader<Types>,
 {
     type Error = PersistenceError;
 
@@ -453,6 +430,10 @@ where
             leaf.payload_hash(),
             leaf.height(),
         );
+        self.index_by_time
+            .entry(leaf.header().timestamp())
+            .or_default()
+            .push(leaf.height());
         Ok(())
     }
 
@@ -481,12 +462,8 @@ where
         common: VidCommonQueryData<Types>,
         share: Option<VidShare>,
     ) -> Result<(), Self::Error> {
-        let height = common.height();
-        let block_hash = common.block_hash();
-        let payload_hash = common.payload_hash();
-        self.vid_storage.insert(height as usize, (common, share))?;
-        update_index_by_hash(&mut self.index_vid_by_block_hash, block_hash, height);
-        update_index_by_hash(&mut self.index_vid_by_payload_hash, payload_hash, height);
+        self.vid_storage
+            .insert(common.height() as usize, (common, share))?;
         Ok(())
     }
 }
@@ -513,6 +490,7 @@ fn update_index_by_hash<H: Eq + Hash, P: Ord>(index: &mut HashMap<H, P>, hash: H
 impl<Types: NodeType> NodeDataSource<Types> for FileSystemStorage<Types>
 where
     Payload<Types>: QueryablePayload,
+    Header<Types>: QueryableHeader<Types>,
 {
     async fn block_height(&self) -> QueryResult<usize> {
         Ok(self.leaf_storage.iter().len())
@@ -560,7 +538,7 @@ where
     {
         self.vid_storage
             .iter()
-            .nth(self.get_vid_index(id.into())?)
+            .nth(self.get_block_index(id.into())?)
             .context(NotFoundSnafu)?
             .context(MissingSnafu)?
             .1
@@ -587,5 +565,51 @@ where
             missing_vid_shares: missing_vid + null_vid_shares,
             pruned_height: None,
         })
+    }
+
+    async fn get_header_window(
+        &self,
+        start: impl Into<WindowStart<Types>> + Send + Sync,
+        end: u64,
+    ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
+        let first_block = match start.into() {
+            WindowStart::Height(h) => h,
+            WindowStart::Hash(h) => self.get_header(h.into()).await?.block_number(),
+            WindowStart::Time(t) => {
+                // Find the minimum timestamp which is at least `t`, and all the blocks with that
+                // timestamp.
+                let blocks = self
+                    .index_by_time
+                    .range(t..)
+                    .next()
+                    .context(NotFoundSnafu)?
+                    .1;
+                // Multiple blocks can have the same timestamp (when truncated to seconds); we want
+                // the first one. It is an invariant that any timestamp which has an entry in
+                // `index_by_time` has a non-empty list associated with it, so this indexing is
+                // safe.
+                blocks[0]
+            }
+        } as usize;
+
+        let mut res = TimeWindowQueryData::default();
+
+        // Include the block just before the start of the window, if there is one.
+        if first_block > 0 {
+            res.prev = Some(self.get_header((first_block - 1).into()).await?);
+        }
+
+        // Add blocks to the window, starting from `first_block`, until we reach the end of the
+        // requested time window.
+        for block in self.get_block_range(first_block..).await? {
+            let header = block?.header().clone();
+            if header.timestamp() >= end {
+                res.next = Some(header);
+                break;
+            }
+            res.window.push(header);
+        }
+
+        Ok(res)
     }
 }

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     data_source::VersionedDataSource,
     node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
-    Header, Payload, QueryError, QueryResult, SignatureKey, VidShare,
+    Header, Payload, QueryError, QueryResult, VidShare,
 };
 use async_trait::async_trait;
 use hotshot_types::traits::node_implementation::NodeType;
@@ -156,18 +156,6 @@ where
 {
     async fn block_height(&self) -> QueryResult<usize> {
         Ok(0)
-    }
-
-    async fn get_proposals(
-        &self,
-        _id: &SignatureKey<Types>,
-        _limit: Option<usize>,
-    ) -> QueryResult<Vec<LeafQueryData<Types>>> {
-        Err(QueryError::Missing)
-    }
-
-    async fn count_proposals(&self, _id: &SignatureKey<Types>) -> QueryResult<usize> {
-        Err(QueryError::Missing)
     }
 
     async fn count_transactions(&self) -> QueryResult<usize> {
@@ -499,24 +487,6 @@ pub mod testing {
             match self {
                 Self::Sql(data_source) => NodeDataSource::block_height(data_source).await,
                 Self::NoStorage(data_source) => NodeDataSource::block_height(data_source).await,
-            }
-        }
-
-        async fn get_proposals(
-            &self,
-            proposer: &SignatureKey<MockTypes>,
-            limit: Option<usize>,
-        ) -> QueryResult<Vec<LeafQueryData<MockTypes>>> {
-            match self {
-                Self::Sql(data_source) => data_source.get_proposals(proposer, limit).await,
-                Self::NoStorage(data_source) => data_source.get_proposals(proposer, limit).await,
-            }
-        }
-
-        async fn count_proposals(&self, proposer: &SignatureKey<MockTypes>) -> QueryResult<usize> {
-            match self {
-                Self::Sql(data_source) => data_source.count_proposals(proposer).await,
-                Self::NoStorage(data_source) => data_source.count_proposals(proposer).await,
             }
         }
 

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -21,7 +21,7 @@ use crate::{
         TransactionHash, TransactionIndex, UpdateAvailabilityData, VidCommonQueryData,
     },
     data_source::VersionedDataSource,
-    node::{NodeDataSource, SyncStatus},
+    node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
     Header, Payload, QueryError, QueryResult, SignatureKey, VidShare,
 };
 use async_trait::async_trait;
@@ -186,6 +186,14 @@ where
     }
 
     async fn sync_status(&self) -> QueryResult<SyncStatus> {
+        Err(QueryError::Missing)
+    }
+
+    async fn get_header_window(
+        &self,
+        _start: impl Into<WindowStart<Types>> + Send + Sync,
+        _end: u64,
+    ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
         Err(QueryError::Missing)
     }
 }
@@ -540,6 +548,17 @@ pub mod testing {
             match self {
                 Self::Sql(data_source) => data_source.sync_status().await,
                 Self::NoStorage(data_source) => data_source.sync_status().await,
+            }
+        }
+
+        async fn get_header_window(
+            &self,
+            start: impl Into<WindowStart<MockTypes>> + Send + Sync,
+            end: u64,
+        ) -> QueryResult<TimeWindowQueryData<Header<MockTypes>>> {
+            match self {
+                Self::Sql(data_source) => data_source.get_header_window(start, end).await,
+                Self::NoStorage(data_source) => data_source.get_header_window(start, end).await,
             }
         }
     }

--- a/src/fetching/provider/any.rs
+++ b/src/fetching/provider/any.rs
@@ -207,6 +207,7 @@ mod test {
             mocks::MockTypes,
             setup_test,
         },
+        types::HeightIndexed,
         Error,
     };
     use async_std::task::spawn;

--- a/src/fetching/provider/query_service.rs
+++ b/src/fetching/provider/query_service.rs
@@ -178,6 +178,7 @@ mod test {
             mocks::{mock_transaction, MockTypes},
             setup_test, sleep,
         },
+        types::HeightIndexed,
         VidCommitment,
     };
     use async_std::task::spawn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,13 +258,15 @@
 //!
 //! ```
 //! # use async_trait::async_trait;
-//! # use hotshot_query_service::{QueryResult, SignatureKey, VidShare};
+//! # use hotshot_query_service::{Header, QueryResult, SignatureKey, VidShare};
 //! # use hotshot_query_service::availability::{
 //! #   AvailabilityDataSource, BlockId, BlockQueryData, Fetch, LeafId, LeafQueryData,
 //! #   PayloadQueryData, TransactionHash, TransactionIndex, VidCommonQueryData,
 //! # };
 //! # use hotshot_query_service::metrics::PrometheusMetrics;
-//! # use hotshot_query_service::node::{NodeDataSource, SyncStatus};
+//! # use hotshot_query_service::node::{
+//! #   NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart,
+//! # };
 //! # use hotshot_query_service::status::StatusDataSource;
 //! # use hotshot_query_service::testing::mocks::MockTypes as AppTypes;
 //! # use std::ops::RangeBounds;
@@ -363,6 +365,14 @@
 //!     async fn sync_status(&self) -> QueryResult<SyncStatus> {
 //!         self.hotshot_qs.sync_status().await
 //!     }
+//!
+//!     async fn get_header_window(
+//!         &self,
+//!         start: impl Into<WindowStart<AppTypes>> + Send + Sync,
+//!         end: u64,
+//!     ) -> QueryResult<TimeWindowQueryData<Header<AppTypes>>> {
+//!         self.hotshot_qs.get_header_window(start, end).await
+//!     }
 //! }
 //!
 //! // Implement data source trait for status API by delegating to the underlying data source.
@@ -413,6 +423,7 @@ mod resolvable;
 pub mod status;
 mod task;
 pub mod testing;
+pub mod types;
 
 pub use error::Error;
 pub use resolvable::Resolvable;
@@ -545,7 +556,7 @@ mod test {
             VidCommonQueryData,
         },
         metrics::PrometheusMetrics,
-        node::{NodeDataSource, SyncStatus},
+        node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
         status::StatusDataSource,
         testing::{
             consensus::MockDataSource,
@@ -687,6 +698,13 @@ mod test {
         }
         async fn sync_status(&self) -> QueryResult<SyncStatus> {
             self.hotshot_qs.sync_status().await
+        }
+        async fn get_header_window(
+            &self,
+            start: impl Into<WindowStart<MockTypes>> + Send + Sync,
+            end: u64,
+        ) -> QueryResult<TimeWindowQueryData<Header<MockTypes>>> {
+            self.hotshot_qs.get_header_window(start, end).await
         }
     }
 

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -24,10 +24,28 @@
 //! updated implicitly via the [availability API update
 //! trait](crate::availability::UpdateAvailabilityData).
 
-use super::query_data::{BlockId, LeafQueryData, SyncStatus};
-use crate::{QueryResult, SignatureKey, VidShare};
+use super::query_data::{BlockHash, BlockId, LeafQueryData, SyncStatus, TimeWindowQueryData};
+use crate::{Header, QueryResult, SignatureKey, VidShare};
 use async_trait::async_trait;
+use derivative::Derivative;
+use derive_more::From;
 use hotshot_types::traits::node_implementation::NodeType;
+
+#[derive(Derivative, From)]
+#[derivative(Copy(bound = ""), Debug(bound = ""))]
+pub enum WindowStart<Types: NodeType> {
+    #[from(ignore)]
+    Time(u64),
+    #[from(ignore)]
+    Height(u64),
+    Hash(BlockHash<Types>),
+}
+
+impl<Types: NodeType> Clone for WindowStart<Types> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 #[async_trait]
 pub trait NodeDataSource<Types: NodeType> {
@@ -44,4 +62,9 @@ pub trait NodeDataSource<Types: NodeType> {
     where
         ID: Into<BlockId<Types>> + Send + Sync;
     async fn sync_status(&self) -> QueryResult<SyncStatus>;
+    async fn get_header_window(
+        &self,
+        start: impl Into<WindowStart<Types>> + Send + Sync,
+        end: u64,
+    ) -> QueryResult<TimeWindowQueryData<Header<Types>>>;
 }

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -24,8 +24,8 @@
 //! updated implicitly via the [availability API update
 //! trait](crate::availability::UpdateAvailabilityData).
 
-use super::query_data::{BlockHash, BlockId, LeafQueryData, SyncStatus, TimeWindowQueryData};
-use crate::{Header, QueryResult, SignatureKey, VidShare};
+use super::query_data::{BlockHash, BlockId, SyncStatus, TimeWindowQueryData};
+use crate::{Header, QueryResult, VidShare};
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::From;
@@ -50,12 +50,6 @@ impl<Types: NodeType> Clone for WindowStart<Types> {
 #[async_trait]
 pub trait NodeDataSource<Types: NodeType> {
     async fn block_height(&self) -> QueryResult<usize>;
-    async fn get_proposals(
-        &self,
-        proposer: &SignatureKey<Types>,
-        limit: Option<usize>,
-    ) -> QueryResult<Vec<LeafQueryData<Types>>>;
-    async fn count_proposals(&self, proposer: &SignatureKey<Types>) -> QueryResult<usize>;
     async fn count_transactions(&self) -> QueryResult<usize>;
     async fn payload_size(&self) -> QueryResult<usize>;
     async fn vid_share<ID>(&self, id: ID) -> QueryResult<VidShare>

--- a/src/node/query_data.rs
+++ b/src/node/query_data.rs
@@ -10,9 +10,11 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
+use crate::types::HeightIndexed;
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-pub use crate::availability::{BlockId, LeafQueryData};
+pub use crate::availability::{BlockHash, BlockId, LeafQueryData};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct SyncStatus {
@@ -36,5 +38,26 @@ impl SyncStatus {
 
     pub fn is_fully_synced(&self) -> bool {
         *self == Self::fully_synced()
+    }
+}
+
+/// Response to a `/:resource/window` query.
+#[derive(Clone, Debug, Derivative, PartialEq, Eq, Serialize, Deserialize)]
+#[derivative(Default(bound = ""))]
+pub struct TimeWindowQueryData<T> {
+    pub window: Vec<T>,
+    pub prev: Option<T>,
+    pub next: Option<T>,
+}
+
+impl<T: HeightIndexed> TimeWindowQueryData<T> {
+    /// The block height of the block that starts the window.
+    ///
+    /// If the window is empty, this is the height of the block that ends the window.
+    pub fn from(&self) -> Option<u64> {
+        self.window
+            .first()
+            .or(self.next.as_ref())
+            .map(|t| t.height())
     }
 }

--- a/src/node/query_data.rs
+++ b/src/node/query_data.rs
@@ -14,7 +14,7 @@ use crate::types::HeightIndexed;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-pub use crate::availability::{BlockHash, BlockId, LeafQueryData};
+pub use crate::availability::{BlockHash, BlockId};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct SyncStatus {

--- a/src/testing/mocks.rs
+++ b/src/testing/mocks.rs
@@ -10,8 +10,10 @@
 // You should have received a copy of the GNU General Public License along with this program. If not,
 // see <https://www.gnu.org/licenses/>.
 
-use crate::availability::{QueryableHeader, QueryablePayload};
-use chrono::Utc;
+use crate::{
+    availability::{QueryableHeader, QueryablePayload},
+    types::HeightIndexed,
+};
 use hotshot::traits::{
     election::static_committee::{GeneralStaticCommittee, StaticElectionConfig},
     implementations::{MemoryNetwork, MemoryStorage},
@@ -38,9 +40,15 @@ pub fn mock_transaction(payload: Vec<u8>) -> MockTransaction {
     TestTransaction(payload)
 }
 
-impl<Types: NodeType<BlockPayload = TestBlockPayload>> QueryableHeader<Types> for MockHeader {
+impl QueryableHeader<MockTypes> for MockHeader {
     fn timestamp(&self) -> u64 {
-        Utc::now().timestamp() as u64
+        self.timestamp
+    }
+}
+
+impl HeightIndexed for MockHeader {
+    fn height(&self) -> u64 {
+        self.block_number
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the HotShot Query Service library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not,
+// see <https://www.gnu.org/licenses/>.
+
+//! Common functionality provided by types used in this crate.
+
+/// Types which have a notion of "height" within a chain.
+pub trait HeightIndexed {
+    fn height(&self) -> u64;
+}


### PR DESCRIPTION
Now that we have access to the header timestamp in the query service (needed for pruning) we can implement timestamp queries, moving this functionality from extensions in the sequencer into the core query service.

Conversely, since the proposer address has been moved into the block header and integrated with the Espresso fee system, it no longer makes sense to have proposer endpoints in the core query service. These can be implemented as extensions that rely on the specific structure of the sequencer header, if they are needed at all.