### PR TITLE
Clean up shutdown

### DIFF
--- a/examples/simple-server.rs
+++ b/examples/simple-server.rs
@@ -72,7 +72,7 @@ async fn init_db() -> Db {
 
 #[cfg(target_os = "windows")]
 async fn init_db() -> Db {
-    Db::new().unwrap()
+    Db::with_prefix("simple-server-db").unwrap()
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/data_source/fs.rs
+++ b/src/data_source/fs.rs
@@ -244,8 +244,8 @@ mod impl_testable_data_source {
     {
         type Storage = TempDir;
 
-        async fn create(_node_id: usize) -> Self::Storage {
-            TempDir::new().unwrap()
+        async fn create(node_id: usize) -> Self::Storage {
+            TempDir::with_prefix(format!("file_system_data_source_{node_id}")).unwrap()
         }
 
         async fn connect(storage: &Self::Storage) -> Self {

--- a/src/data_source/storage/ledger_log.rs
+++ b/src/data_source/storage/ledger_log.rs
@@ -277,7 +277,7 @@ mod test {
     async fn test_ledger_log_creation() {
         setup_test();
 
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::with_prefix("test_ledger_log").unwrap();
 
         // Create and populuate a log.
         {
@@ -307,7 +307,7 @@ mod test {
     async fn test_ledger_log_insert() {
         setup_test();
 
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::with_prefix("test_ledger_log").unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_ledger_log").unwrap();
         let mut log = LedgerLog::<u64>::create(&mut loader, "ledger", 3).unwrap();
         let mut store = AtomicStore::open(loader).unwrap();
@@ -351,7 +351,7 @@ mod test {
     async fn test_ledger_log_iter() {
         setup_test();
 
-        let dir = TempDir::new().unwrap();
+        let dir = TempDir::with_prefix("test_ledger_log").unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_ledger_log").unwrap();
         let mut log = LedgerLog::<u64>::create(&mut loader, "ledger", 3).unwrap();
         let mut store = AtomicStore::open(loader).unwrap();

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -205,7 +205,6 @@ pub mod testing {
         },
         Error,
     };
-    use async_std::task::spawn;
     use futures::stream::{BoxStream, StreamExt};
     use hotshot::types::Event;
     use portpicker::pick_unused_port;
@@ -290,7 +289,7 @@ pub mod testing {
             }
         }
 
-        async fn setup(network: &MockNetwork<Self>) {
+        async fn setup(network: &mut MockNetwork<Self>) {
             // Spawn the web server on node 1 that node 0 will use to fetch missing data.
             let Storage::NoStorage { fetch_from_port } = network.storage() else {
                 panic!("node 0 should always be NoStorage node");
@@ -300,7 +299,7 @@ pub mod testing {
             let mut app = App::<_, Error>::with_state(api_data_source);
             app.register_module("availability", define_api(&Default::default()).unwrap())
                 .unwrap();
-            spawn(app.serve(format!("0.0.0.0:{fetch_from_port}")));
+            network.spawn("server", app.serve(format!("0.0.0.0:{fetch_from_port}")));
         }
 
         async fn handle_event(&mut self, event: &Event<MockTypes>) {

--- a/src/fetching/provider/any.rs
+++ b/src/fetching/provider/any.rs
@@ -202,6 +202,7 @@ mod test {
         availability::{define_api, AvailabilityDataSource, UpdateAvailabilityData},
         data_source::{storage::sql::testing::TmpDb, VersionedDataSource},
         fetching::provider::{NoFetching, QueryServiceProvider},
+        task::BackgroundTask,
         testing::{
             consensus::{MockDataSource, MockNetwork},
             mocks::MockTypes,
@@ -210,7 +211,6 @@ mod test {
         types::HeightIndexed,
         Error,
     };
-    use async_std::task::spawn;
     use futures::stream::StreamExt;
     use portpicker::pick_unused_port;
     use tide_disco::App;
@@ -229,7 +229,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        let _server = BackgroundTask::spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;

--- a/src/fetching/provider/query_service.rs
+++ b/src/fetching/provider/query_service.rs
@@ -181,7 +181,6 @@ mod test {
         types::HeightIndexed,
         VidCommitment,
     };
-    use async_std::task::spawn;
     use commit::Committable;
     use futures::{
         future::{join, FutureExt},
@@ -231,7 +230,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
@@ -451,7 +450,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
@@ -503,7 +502,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
@@ -559,7 +558,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
@@ -612,7 +611,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus, only from a peer.
         let db = TmpDb::init().await;
@@ -666,7 +665,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus. We don't give it a
         // fetcher since transactions are always fetched passively anyways.
@@ -734,7 +733,7 @@ mod test {
         let mut app = App::<_, Error>::with_state(network.data_source());
         app.register_module("availability", define_api(&Default::default()).unwrap())
             .unwrap();
-        spawn(app.serve(format!("0.0.0.0:{port}")));
+        network.spawn("server", app.serve(format!("0.0.0.0:{port}")));
 
         // Start a data source which is not receiving events from consensus.
         let db = TmpDb::init().await;


### PR DESCRIPTION
* Switch temp storage from tempdir (deprecated) to tempfile
* Ensure all async tasks get shut down
* Yield periodically in update task to make cancellation more responsive

Depends on #457 
Closes #346 