### PR TITLE
Cargo audit fixes, separate CI job

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+    # remove_dir_all (used by deprecated tempdir crate)
+    "RUSTSEC-2023-0018",
+    # DoS in WebPKI that comes with tide_disco
+    "RUSTSEC-2023-0052",
+    # Tungstenite allows remote attackers to cause a denial of service
+    # Dependency of async-tungstenite -> tide-websockets / surf-disco
+    "RUSTSEC-2023-0065",
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Security audit
+on:
+  push:
+    # For PR we only want to fail if dependencies were changed.
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  # Run the audit job once a day on main.
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # See https://github.com/marketplace/actions/rust-audit-check for docs
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,6 @@ jobs:
           token: ${{ github.token }}
           args: --workspace --all-features --all-targets -- -D warnings
 
-      - name: Audit
-        run: cargo audit --ignore RUSTSEC-2023-0018 --ignore RUSTSEC-2023-0052 --ignore RUSTSEC-2023-0065
-
       - name: Build
         # Build in release without `testing` feature, this should work without `hotshot_example` config.
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -7714,6 +7714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7818,11 +7824,12 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall",
+ "wasite",
  "web-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,12 +2400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,7 +2982,7 @@ dependencies = [
  "spin_sleep",
  "surf",
  "surf-disco",
- "tempdir",
+ "tempfile",
  "tide-disco",
  "time 0.3.34",
  "tokio",
@@ -5572,19 +5566,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -5626,21 +5607,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -5699,15 +5665,6 @@ dependencies = [
  "ring 0.16.20",
  "time 0.3.34",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5817,15 +5774,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "resolv-conf"
@@ -6922,16 +6870,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ testing = [
 	"portpicker",
 	"rand",
 	"spin_sleep",
-	"tempdir",
+	"tempfile",
 ]
 
 [[example]]
@@ -111,7 +111,7 @@ hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git"
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
-tempdir = { version = "0.3", optional = true }
+tempfile = { version = "3.10", optional = true }
 
 # Dependencies enabled by feature "backtrace-on-stack-overflow".
 #
@@ -132,4 +132,4 @@ portpicker = "0.1"
 rand = "0.8"
 spin_sleep = "1.2"
 surf = "2.3"
-tempdir = "0.3"
+tempfile = "3.10"

--- a/examples/simple-server.rs
+++ b/examples/simple-server.rs
@@ -72,7 +72,7 @@ async fn init_db() -> Db {
 
 #[cfg(target_os = "windows")]
 async fn init_db() -> Db {
-    Db::new("simple-server-db").unwrap()
+    Db::new().unwrap()
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -497,7 +497,7 @@ mod test {
     use portpicker::pick_unused_port;
     use std::time::Duration;
     use surf_disco::Client;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use tide_disco::App;
     use toml::toml;
 
@@ -869,7 +869,7 @@ mod test {
     async fn test_extensions() {
         setup_test();
 
-        let dir = TempDir::new("test_availability_extensions").unwrap();
+        let dir = TempDir::new().unwrap();
         let mut data_source = ExtensibleDataSource::new(
             MockDataSource::create(dir.path(), Default::default())
                 .await

--- a/src/data_source/fs.rs
+++ b/src/data_source/fs.rs
@@ -236,7 +236,7 @@ mod impl_testable_data_source {
     };
     use async_trait::async_trait;
     use hotshot::types::Event;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[async_trait]
     impl<P: AvailabilityProvider<MockTypes> + Default> DataSourceLifeCycle
@@ -244,8 +244,8 @@ mod impl_testable_data_source {
     {
         type Storage = TempDir;
 
-        async fn create(node_id: usize) -> Self::Storage {
-            TempDir::new(&format!("file_system_data_source_{node_id}")).unwrap()
+        async fn create(_node_id: usize) -> Self::Storage {
+            TempDir::new().unwrap()
         }
 
         async fn connect(storage: &Self::Storage) -> Self {

--- a/src/data_source/storage/ledger_log.rs
+++ b/src/data_source/storage/ledger_log.rs
@@ -271,13 +271,13 @@ mod test {
     use super::*;
     use crate::testing::setup_test;
     use atomic_store::AtomicStore;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
 
     #[async_std::test]
     async fn test_ledger_log_creation() {
         setup_test();
 
-        let dir = TempDir::new("test_ledger_log").unwrap();
+        let dir = TempDir::new().unwrap();
 
         // Create and populuate a log.
         {
@@ -307,7 +307,7 @@ mod test {
     async fn test_ledger_log_insert() {
         setup_test();
 
-        let dir = TempDir::new("test_ledger_log").unwrap();
+        let dir = TempDir::new().unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_ledger_log").unwrap();
         let mut log = LedgerLog::<u64>::create(&mut loader, "ledger", 3).unwrap();
         let mut store = AtomicStore::open(loader).unwrap();
@@ -351,7 +351,7 @@ mod test {
     async fn test_ledger_log_iter() {
         setup_test();
 
-        let dir = TempDir::new("test_ledger_log").unwrap();
+        let dir = TempDir::new().unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_ledger_log").unwrap();
         let mut log = LedgerLog::<u64>::create(&mut loader, "ledger", 3).unwrap();
         let mut store = AtomicStore::open(loader).unwrap();

--- a/src/data_source/storage/pruning.rs
+++ b/src/data_source/storage/pruning.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the HotShot Query Service library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+// General Public License as published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+// even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not,
+// see <https://www.gnu.org/licenses/>.
+
 use anyhow::bail;
 use async_trait::async_trait;
 use std::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,7 +564,7 @@ mod test {
     use std::ops::RangeBounds;
     use std::time::Duration;
     use surf_disco::Client;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use tide_disco::App;
     use toml::toml;
 
@@ -703,7 +703,7 @@ mod test {
 
     #[async_std::test]
     async fn test_composition() {
-        let dir = TempDir::new("test_composition").unwrap();
+        let dir = TempDir::new().unwrap();
         let mut loader = AtomicStoreLoader::create(dir.path(), "test_composition").unwrap();
         let mut hotshot_qs = MockDataSource::create_with_store(&mut loader, Default::default())
             .await

--- a/src/node.rs
+++ b/src/node.rs
@@ -200,7 +200,7 @@ mod test {
     use portpicker::pick_unused_port;
     use std::time::Duration;
     use surf_disco::Client;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use tide_disco::App;
     use toml::toml;
 
@@ -360,7 +360,7 @@ mod test {
     async fn test_extensions() {
         setup_test();
 
-        let dir = TempDir::new("test_node_extensions").unwrap();
+        let dir = TempDir::new().unwrap();
         let data_source = ExtensibleDataSource::new(
             MockDataSource::create(dir.path(), Default::default())
                 .await

--- a/src/status.rs
+++ b/src/status.rs
@@ -133,7 +133,7 @@ mod test {
     use std::str::FromStr;
     use std::time::Duration;
     use surf_disco::Client;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use tide_disco::{App, Url};
     use toml::toml;
 
@@ -240,7 +240,7 @@ mod test {
     async fn test_extensions() {
         setup_test();
 
-        let dir = TempDir::new("test_status_extensions").unwrap();
+        let dir = TempDir::new().unwrap();
         let data_source = ExtensibleDataSource::new(
             MockDataSource::create(dir.path(), Default::default())
                 .await


### PR DESCRIPTION
More info: https://github.com/rust-lang-deprecated/tempdir/issues/45

This crate is causing cargo-audit to fail due to a dependency on
`remove_dir_all`.

https://rustsec.org/advisories/RUSTSEC-2023-0018