### PR TITLE
Fix: merkle tree commitment parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "hotshot-query-service"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "hotshot-query-service"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@
 
 [package]
 name = "hotshot-query-service"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -1387,7 +1387,7 @@ where
                             "SELECT height FROM Header  where 
                              data->>'{header_state_commitment_field}' = $1"
                         ),
-                        &[&serde_json::to_string(&commit).map_err(ParseError::Serde)?],
+                        &[&commit.to_string()],
                     )
                     .await?;
 
@@ -1402,9 +1402,9 @@ where
                     [sql_param(&created)],
                 )
                 .await?;
-                let commit = row.get(0);
+                let commit: String = row.get(0);
                 let commit: State::Commit =
-                    serde_json::from_str(commit).map_err(ParseError::Serde)?;
+                    serde_json::from_value(commit.into()).map_err(ParseError::Serde)?;
                 (created, commit.digest())
             }
         };
@@ -2856,7 +2856,7 @@ mod test {
             test_tree.update(i, i).unwrap();
 
             // data field of the header
-            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&test_tree.commitment()).unwrap()});
+            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
             storage
                 .query_opt(
                     "INSERT INTO HEADER VALUES ($1, $2, 't', 0, $3) ON CONFLICT(height) DO UPDATE set data = excluded.data",
@@ -2913,7 +2913,7 @@ mod test {
         // Also update the merkle commitment in the header
 
         // data field of the header
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&test_tree.commitment()).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
         storage
             .query_opt(
                 "INSERT INTO HEADER VALUES ($1, $2, 't', 0, $3) ON CONFLICT(height) DO UPDATE set data = excluded.data",
@@ -3002,7 +3002,7 @@ mod test {
         test_tree.update(0, 0).unwrap();
         let commitment = test_tree.commitment();
 
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&commitment).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&commitment).unwrap()});
         // insert the header with merkle commitment
         storage
                 .query_opt(
@@ -3067,7 +3067,7 @@ mod test {
             [
                 sql_param(&2_i64),
                 sql_param(&"randomString2"),
-                sql_param(&serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&test_tree.commitment()).unwrap()})),
+                sql_param(&serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()})),
             ],
         )
         .await
@@ -3119,7 +3119,7 @@ mod test {
         test_tree.update(0, 0).unwrap();
         let commitment = test_tree.commitment();
 
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&commitment).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&commitment).unwrap()});
         // insert the header with merkle commitment
         storage
                 .query_opt(
@@ -3179,7 +3179,7 @@ mod test {
 
         for i in 0..27 {
             test_tree.update(i, i).unwrap();
-            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&test_tree.commitment()).unwrap()});
+            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
             // insert the header with merkle commitment
             storage
                     .query_opt(
@@ -3232,7 +3232,7 @@ mod test {
         .await;
         assert!(merkle_path.is_err());
 
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&test_tree.commitment()).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
         // insert the header with merkle commitment
         storage
                 .query_opt(
@@ -3260,7 +3260,7 @@ mod test {
         test_tree.update(1, 200).unwrap();
 
         let (_, proof) = test_tree.lookup(1).expect_ok().unwrap();
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_string(&test_tree.commitment()).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
 
         // insert the header with merkle commitment
         storage

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -1523,7 +1523,7 @@ where
             Some(MerkleNode::Empty) => State::T::default(),
             Some(_) => {
                 return Err(QueryError::Error {
-                    message: "First node in the proof should be leaf or empty".to_string(),
+                    message: "Missing State ".to_string(),
                 })
             }
             None => return Err(QueryError::Missing),

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -2856,7 +2856,7 @@ mod test {
             test_tree.update(i, i).unwrap();
 
             // data field of the header
-            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
+            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(test_tree.commitment()).unwrap()});
             storage
                 .query_opt(
                     "INSERT INTO HEADER VALUES ($1, $2, 't', 0, $3) ON CONFLICT(height) DO UPDATE set data = excluded.data",
@@ -2913,7 +2913,7 @@ mod test {
         // Also update the merkle commitment in the header
 
         // data field of the header
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(test_tree.commitment()).unwrap()});
         storage
             .query_opt(
                 "INSERT INTO HEADER VALUES ($1, $2, 't', 0, $3) ON CONFLICT(height) DO UPDATE set data = excluded.data",
@@ -3002,7 +3002,7 @@ mod test {
         test_tree.update(0, 0).unwrap();
         let commitment = test_tree.commitment();
 
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&commitment).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(commitment).unwrap()});
         // insert the header with merkle commitment
         storage
                 .query_opt(
@@ -3067,7 +3067,7 @@ mod test {
             [
                 sql_param(&2_i64),
                 sql_param(&"randomString2"),
-                sql_param(&serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()})),
+                sql_param(&serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(test_tree.commitment()).unwrap()})),
             ],
         )
         .await
@@ -3119,7 +3119,7 @@ mod test {
         test_tree.update(0, 0).unwrap();
         let commitment = test_tree.commitment();
 
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&commitment).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(commitment).unwrap()});
         // insert the header with merkle commitment
         storage
                 .query_opt(
@@ -3179,7 +3179,7 @@ mod test {
 
         for i in 0..27 {
             test_tree.update(i, i).unwrap();
-            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
+            let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(test_tree.commitment()).unwrap()});
             // insert the header with merkle commitment
             storage
                     .query_opt(
@@ -3232,7 +3232,7 @@ mod test {
         .await;
         assert!(merkle_path.is_err());
 
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(test_tree.commitment()).unwrap()});
         // insert the header with merkle commitment
         storage
                 .query_opt(
@@ -3260,7 +3260,7 @@ mod test {
         test_tree.update(1, 200).unwrap();
 
         let (_, proof) = test_tree.lookup(1).expect_ok().unwrap();
-        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(&test_tree.commitment()).unwrap()});
+        let test_data = serde_json::json!({ MockMerkleTree::header_state_commitment_field() : serde_json::to_value(test_tree.commitment()).unwrap()});
 
         // insert the header with merkle commitment
         storage


### PR DESCRIPTION
Header data is serialized as serde_json::Value when inserting it into the header table 