### PR TITLE
Move clippy/rustfmt after build/test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,17 +30,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         name: Enable Rust Caching
 
-      - name: Format Check
-        run: cargo fmt -- --check
-
-      # Run Clippy on all targets. The lint workflow doesn't run Clippy on tests, because the tests
-      # don't compile with all combinations of features.
-      - uses: actions-rs/clippy-check@v1
-        name: Clippy
-        with:
-          token: ${{ github.token }}
-          args: --workspace --all-features --all-targets -- -D warnings
-
       - name: Build
         # Build in release without `testing` feature, this should work without `hotshot_example` config.
         run: |
@@ -51,6 +40,17 @@ jobs:
           cargo test --workspace --release --all-features --no-run
           cargo test --workspace --release --all-features --verbose -- --test-threads 2
         timeout-minutes: 60
+
+      - name: Format Check
+        run: cargo fmt -- --check
+
+      # Run Clippy on all targets. The lint workflow doesn't run Clippy on tests, because the tests
+      # don't compile with all combinations of features.
+      - uses: actions-rs/clippy-check@v1
+        name: Clippy
+        with:
+          token: ${{ github.token }}
+          args: --workspace --all-features --all-targets -- -D warnings
 
       - name: Generate Documentation
         run: |


### PR DESCRIPTION
Moves clippy/rustfmt after build/test.

Ideally these should be separated off, but this is just a quick fix.
