### PR TITLE
Fix explorer summary histogram data order

### DIFF
--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -2219,8 +2219,10 @@ where
                 FROM header AS h
                 JOIN payload AS p ON
                     p.height = h.height
-                ORDER BY h.height DESC
-                LIMIT 50",
+                WHERE
+                    h.height IN (SELECT height FROM header ORDER BY height DESC LIMIT 50)
+                ORDER BY h.height ASC 
+                ",
                 Vec::<Box<dyn ToSql + Send + Sync>>::new(),
             ).await?;
 


### PR DESCRIPTION
Closes #593
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
The histogram data for the `get_explorer_summary` endpoint of the `Explorer API` is providing its data in the wrong order.  The data is meant to be delivered in `block height` ascending order.  Instead it's being delivered in `block height` descending order.  This pull request changes the sort order of the data being retrieved in the query itself, which corrects the issue.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
Make any other significant changes to the logic.

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
