### PR TITLE
Fix: TmpDb::init() wait for psql

### DIFF
--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -3097,39 +3097,40 @@ pub mod testing {
             let db = Self {
                 host,
                 port,
-                container_id,
+                container_id: container_id.clone(),
             };
 
             // Wait for the database to be ready.
-            loop {
-                if Command::new("docker")
-                    .args([
-                        "exec",
-                        "-h",
-                        &(db.host()),
-                        "-p",
-                        &(db.port().to_string()),
-                        "-U",
-                        "postgres",
-                        "psql",
-                    ])
-                    .env("PGPASSWORD", "password")
-                    // Null input so the command terminates as soon as it manages to connect.
-                    .stdin(Stdio::null())
-                    // Output from this command is not useful, it's just a prompt.
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status()
-                    .map(|status| status.success())
-                    .is_ok()
-                {
-                    break;
-                } else {
-                    tracing::warn!("database is not ready");
-                    sleep(Duration::from_secs(1)).await;
-                }
+            while Command::new("docker")
+                .args([
+                    "exec",
+                    &container_id,
+                    "pg_isready",
+                    "-h",
+                    "localhost",
+                    "-U",
+                    "postgres",
+                ])
+                .env("PGPASSWORD", "password")
+                // Null input so the command terminates as soon as it manages to connect.
+                .stdin(Stdio::null())
+                .output()
+                .and_then(|output| {
+                    dbg!(&output);
+                    if str::from_utf8(&output.stdout)
+                        .unwrap()
+                        .contains("accepting connections")
+                    {
+                        Ok(())
+                    } else {
+                        Err(std::io::Error::from_raw_os_error(32))
+                    }
+                })
+                .is_err()
+            {
+                tracing::warn!("database is not ready");
+                sleep(Duration::from_secs(1)).await;
             }
-
             db
         }
 

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -3114,6 +3114,9 @@ pub mod testing {
                 .env("PGPASSWORD", "password")
                 // Null input so the command terminates as soon as it manages to connect.
                 .stdin(Stdio::null())
+                // Discard command output.
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .status()
                 // We should ensure the exit status. A simple `unwrap`
                 // would panic on unrelated errors (such as network


### PR DESCRIPTION
Currently `TmpDb::init()` attempts to wait for postgres to become ready,
but the logic will panic if `psql` is not available on the
host. But, we should not have any expectation that `psql` be available
on the host. This PR updates the wait loop to run a query w/ `psql` inside
the docker container.

NOTE due to incoming hotshot and sequencer changes this hasn't been properly tested so there
may be some bugs. Once hotshot is updated we can test this properly.