### PR TITLE
Fine tune locking to minimize critical sections

### DIFF
--- a/src/availability.rs
+++ b/src/availability.rs
@@ -750,7 +750,13 @@ mod test {
         setup_test();
 
         // Create the consensus network.
-        let mut network = MockNetwork::<D>::init().await;
+        let mut network = MockNetwork::<D>::init_with_config(|cfg| {
+            // Make the rate of empty block production slower than the API fetching timeout.
+            // Otherwise, we will produce new blocks faster than we can fetch them (particularly in
+            // the no-storage case, where fetching is quite slow) and the test will never finish.
+            cfg.builder_timeout = fetch_timeout + Duration::from_millis(500);
+        })
+        .await;
         network.start().await;
 
         // Start the web server.

--- a/src/availability.rs
+++ b/src/availability.rs
@@ -140,31 +140,28 @@ where
     let timeout = options.fetch_timeout;
 
     api.with_version("0.0.1".parse().unwrap())
-        .get("get_leaf", move |req, state| {
+        .at("get_leaf", move |req, state| {
             async move {
                 let id = match req.opt_integer_param("height")? {
                     Some(height) => LeafId::Number(height),
                     None => LeafId::Hash(req.blob_param("hash")?),
                 };
-                state
-                    .get_leaf(id)
-                    .await
-                    .with_timeout(timeout)
-                    .await
-                    .context(FetchLeafSnafu {
-                        resource: id.to_string(),
-                    })
+                let fetch = state.read(|state| state.get_leaf(id).boxed()).await;
+                fetch.with_timeout(timeout).await.context(FetchLeafSnafu {
+                    resource: id.to_string(),
+                })
             }
             .boxed()
         })?
-        .get("get_leaf_range", move |req, state| {
+        .at("get_leaf_range", move |req, state| {
             async move {
                 let from = req.integer_param::<_, usize>("from")?;
                 let until = req.integer_param("until")?;
 
-                state
-                    .get_leaf_range(from..until)
-                    .await
+                let leaves = state
+                    .read(|state| state.get_leaf_range(from..until).boxed())
+                    .await;
+                leaves
                     .enumerate()
                     .then(|(index, fetch)| async move {
                         fetch.with_timeout(timeout).await.context(FetchLeafSnafu {
@@ -188,7 +185,7 @@ where
             .try_flatten_stream()
             .boxed()
         })?
-        .get("get_header", move |req, state| {
+        .at("get_header", move |req, state| {
             async move {
                 let id = if let Some(height) = req.opt_integer_param("height")? {
                     BlockId::Number(height)
@@ -197,9 +194,8 @@ where
                 } else {
                     BlockId::PayloadHash(req.blob_param("payload-hash")?)
                 };
-                Ok(state
-                    .get_block(id)
-                    .await
+                let fetch = state.read(|state| state.get_block(id).boxed()).await;
+                Ok(fetch
                     .with_timeout(timeout)
                     .await
                     .context(FetchBlockSnafu {
@@ -210,14 +206,15 @@ where
             }
             .boxed()
         })?
-        .get("get_header_range", move |req, state| {
+        .at("get_header_range", move |req, state| {
             async move {
                 let from = req.integer_param::<_, usize>("from")?;
                 let until = req.integer_param::<_, usize>("until")?;
 
-                state
-                    .get_block_range(from..until)
-                    .await
+                let headers = state
+                    .read(|state| state.get_block_range(from..until).boxed())
+                    .await;
+                headers
                     .enumerate()
                     .then(|(index, fetch)| async move {
                         fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
@@ -248,7 +245,7 @@ where
             .try_flatten_stream()
             .boxed()
         })?
-        .get("get_block", move |req, state| {
+        .at("get_block", move |req, state| {
             async move {
                 let id = if let Some(height) = req.opt_integer_param("height")? {
                     BlockId::Number(height)
@@ -257,25 +254,22 @@ where
                 } else {
                     BlockId::PayloadHash(req.blob_param("payload-hash")?)
                 };
-                state
-                    .get_block(id)
-                    .await
-                    .with_timeout(timeout)
-                    .await
-                    .context(FetchBlockSnafu {
-                        resource: id.to_string(),
-                    })
+                let fetch = state.read(|state| state.get_block(id).boxed()).await;
+                fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
+                    resource: id.to_string(),
+                })
             }
             .boxed()
         })?
-        .get("get_block_range", move |req, state| {
+        .at("get_block_range", move |req, state| {
             async move {
                 let from = req.integer_param::<_, usize>("from")?;
                 let until = req.integer_param("until")?;
 
-                state
-                    .get_block_range(from..until)
-                    .await
+                let blocks = state
+                    .read(|state| state.get_block_range(from..until).boxed())
+                    .await;
+                blocks
                     .enumerate()
                     .then(|(index, fetch)| async move {
                         fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
@@ -299,7 +293,7 @@ where
             .try_flatten_stream()
             .boxed()
         })?
-        .get("get_payload", move |req, state| {
+        .at("get_payload", move |req, state| {
             async move {
                 let id = if let Some(height) = req.opt_integer_param("height")? {
                     BlockId::Number(height)
@@ -308,25 +302,22 @@ where
                 } else {
                     BlockId::Hash(req.blob_param("block-hash")?)
                 };
-                state
-                    .get_payload(id)
-                    .await
-                    .with_timeout(timeout)
-                    .await
-                    .context(FetchBlockSnafu {
-                        resource: id.to_string(),
-                    })
+                let fetch = state.read(|state| state.get_payload(id).boxed()).await;
+                fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
+                    resource: id.to_string(),
+                })
             }
             .boxed()
         })?
-        .get("get_payload_range", move |req, state| {
+        .at("get_payload_range", move |req, state| {
             async move {
                 let from = req.integer_param::<_, usize>("from")?;
                 let until = req.integer_param("until")?;
 
-                state
-                    .get_payload_range(from..until)
-                    .await
+                let payloads = state
+                    .read(|state| state.get_payload_range(from..until).boxed())
+                    .await;
+                payloads
                     .enumerate()
                     .then(|(index, fetch)| async move {
                         fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
@@ -350,7 +341,7 @@ where
             .try_flatten_stream()
             .boxed()
         })?
-        .get("get_vid_common", move |req, state| {
+        .at("get_vid_common", move |req, state| {
             async move {
                 let id = if let Some(height) = req.opt_integer_param("height")? {
                     BlockId::Number(height)
@@ -359,14 +350,10 @@ where
                 } else {
                     BlockId::PayloadHash(req.blob_param("payload-hash")?)
                 };
-                state
-                    .get_vid_common(id)
-                    .await
-                    .with_timeout(timeout)
-                    .await
-                    .context(FetchBlockSnafu {
-                        resource: id.to_string(),
-                    })
+                let fetch = state.read(|state| state.get_vid_common(id).boxed()).await;
+                fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
+                    resource: id.to_string(),
+                })
             }
             .boxed()
         })?
@@ -382,27 +369,28 @@ where
             .try_flatten_stream()
             .boxed()
         })?
-        .get("get_transaction", move |req, state| {
+        .at("get_transaction", move |req, state| {
             async move {
                 match req.opt_blob_param("hash")? {
-                    Some(hash) => state
-                        .get_transaction(hash)
-                        .await
-                        .with_timeout(timeout)
-                        .await
-                        .context(FetchTransactionSnafu {
-                            resource: hash.to_string(),
-                        }),
-                    None => {
-                        let height: u64 = req.integer_param("height")?;
-                        let block = state
-                            .get_block(height as usize)
-                            .await
+                    Some(hash) => {
+                        let fetch = state
+                            .read(|state| state.get_transaction(hash).boxed())
+                            .await;
+                        fetch
                             .with_timeout(timeout)
                             .await
-                            .context(FetchBlockSnafu {
-                                resource: height.to_string(),
-                            })?;
+                            .context(FetchTransactionSnafu {
+                                resource: hash.to_string(),
+                            })
+                    }
+                    None => {
+                        let height: u64 = req.integer_param("height")?;
+                        let fetch = state
+                            .read(|state| state.get_block(height as usize).boxed())
+                            .await;
+                        let block = fetch.with_timeout(timeout).await.context(FetchBlockSnafu {
+                            resource: height.to_string(),
+                        })?;
                         let i: u64 = req.integer_param("index")?;
                         let index = block
                             .payload()
@@ -415,13 +403,12 @@ where
             }
             .boxed()
         })?
-        .get("get_block_summary", move |req, state| {
+        .at("get_block_summary", move |req, state| {
             async move {
                 let id: usize = req.integer_param("height")?;
 
-                state
-                    .get_block(id)
-                    .await
+                let fetch = state.read(|state| state.get_block(id).boxed()).await;
+                fetch
                     .with_timeout(timeout)
                     .await
                     .context(FetchBlockSnafu {
@@ -431,14 +418,15 @@ where
             }
             .boxed()
         })?
-        .get("get_block_summary_range", move |req, state| {
+        .at("get_block_summary_range", move |req, state| {
             async move {
                 let from: usize = req.integer_param("from")?;
                 let until: usize = req.integer_param("until")?;
 
-                let result: Vec<BlockSummaryQueryData<Types>> = state
-                    .get_block_range(from..until)
-                    .await
+                let blocks = state
+                    .read(|state| state.get_block_range(from..until).boxed())
+                    .await;
+                let result: Vec<BlockSummaryQueryData<Types>> = blocks
                     .enumerate()
                     .then(|(index, fetch)| async move {
                         fetch.with_timeout(timeout).await.context(FetchBlockSnafu {

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -634,14 +634,14 @@ pub mod node_tests {
             .collect::<Vec<_>>();
 
         // At first, the node is fully synced.
-        assert!(ds.sync_status().await.unwrap().is_fully_synced());
+        assert!(ds.sync_status().await.await.unwrap().is_fully_synced());
 
         // Insert a leaf without the corresponding block or VID info, make sure we detect that the
         // block and VID info are missing.
         ds.insert_leaf(leaves[0].clone()).await.unwrap();
         ds.commit().await.unwrap();
         assert_eq!(
-            ds.sync_status().await.unwrap(),
+            ds.sync_status().await.await.unwrap(),
             SyncStatus {
                 missing_blocks: 1,
                 missing_vid_common: 1,
@@ -656,7 +656,7 @@ pub mod node_tests {
         ds.insert_leaf(leaves[2].clone()).await.unwrap();
         ds.commit().await.unwrap();
         assert_eq!(
-            ds.sync_status().await.unwrap(),
+            ds.sync_status().await.await.unwrap(),
             SyncStatus {
                 missing_blocks: 3,
                 missing_vid_common: 3,
@@ -670,7 +670,7 @@ pub mod node_tests {
         ds.insert_vid(vid[0].0.clone(), None).await.unwrap();
         ds.commit().await.unwrap();
         assert_eq!(
-            ds.sync_status().await.unwrap(),
+            ds.sync_status().await.await.unwrap(),
             SyncStatus {
                 missing_blocks: 3,
                 missing_vid_common: 2,
@@ -715,12 +715,12 @@ pub mod node_tests {
             missing_vid_shares: expected_missing,
             pruned_height: None,
         };
-        assert_eq!(ds.sync_status().await.unwrap(), expected_sync_status);
+        assert_eq!(ds.sync_status().await.await.unwrap(), expected_sync_status);
 
         // If we re-insert one of the VID entries without a share, it should not overwrite the share
         // that we already have; that is, `insert_vid` should be monotonic.
         ds.insert_vid(vid[0].0.clone(), None).await.unwrap();
-        assert_eq!(ds.sync_status().await.unwrap(), expected_sync_status);
+        assert_eq!(ds.sync_status().await.await.unwrap(), expected_sync_status);
     }
 
     #[async_std::test]

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -28,6 +28,7 @@ use crate::{
     Header, Payload, QueryResult, Transaction, VidShare,
 };
 use async_trait::async_trait;
+use futures::future::BoxFuture;
 use hotshot_types::traits::node_implementation::NodeType;
 use jf_merkle_tree::prelude::MerkleProof;
 use std::ops::RangeBounds;
@@ -255,7 +256,7 @@ where
     {
         self.data_source.vid_share(id).await
     }
-    async fn sync_status(&self) -> QueryResult<SyncStatus> {
+    async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>> {
         self.data_source.sync_status().await
     }
     async fn get_header_window(

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -742,7 +742,7 @@ where
         self.storage().await.vid_share(id).await
     }
 
-    async fn sync_status(&self) -> QueryResult<SyncStatus> {
+    async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>> {
         self.storage().await.sync_status().await
     }
 

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -26,6 +26,7 @@ use crate::{
     Header, Payload, QueryError, QueryResult, VidShare,
 };
 use async_trait::async_trait;
+use futures::future::{self, BoxFuture, FutureExt};
 use hotshot_types::traits::node_implementation::NodeType;
 use std::{convert::Infallible, ops::RangeBounds};
 
@@ -174,8 +175,8 @@ where
         Err(QueryError::Missing)
     }
 
-    async fn sync_status(&self) -> QueryResult<SyncStatus> {
-        Err(QueryError::Missing)
+    async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>> {
+        future::ready(Err(QueryError::Missing)).boxed()
     }
 
     async fn get_header_window(
@@ -533,7 +534,7 @@ pub mod testing {
             }
         }
 
-        async fn sync_status(&self) -> QueryResult<SyncStatus> {
+        async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>> {
             match self {
                 Self::Sql(data_source) => data_source.sync_status().await,
                 Self::NoStorage(data_source) => data_source.sync_status().await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,7 +561,7 @@ mod test {
     use async_std::sync::RwLock;
     use async_trait::async_trait;
     use atomic_store::{load_store::BincodeLoadStore, AtomicStore, AtomicStoreLoader, RollingLog};
-    use futures::FutureExt;
+    use futures::future::{BoxFuture, FutureExt};
     use hotshot_example_types::state_types::{TestInstanceState, TestValidatedState};
     use hotshot_types::constants::{Version01, STATIC_VER_0_1};
     use portpicker::pick_unused_port;
@@ -679,7 +679,7 @@ mod test {
         {
             self.hotshot_qs.vid_share(id).await
         }
-        async fn sync_status(&self) -> QueryResult<SyncStatus> {
+        async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>> {
             self.hotshot_qs.sync_status().await
         }
         async fn get_header_window(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,7 @@
 //!
 //! ```
 //! # use async_trait::async_trait;
+//! # use futures::future::BoxFuture;
 //! # use hotshot_query_service::{Header, QueryResult, VidShare};
 //! # use hotshot_query_service::availability::{
 //! #   AvailabilityDataSource, BlockId, BlockQueryData, Fetch, LeafId, LeafQueryData,
@@ -356,7 +357,7 @@
 //!         self.hotshot_qs.vid_share(id).await
 //!     }
 //!
-//!     async fn sync_status(&self) -> QueryResult<SyncStatus> {
+//!     async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>> {
 //!         self.hotshot_qs.sync_status().await
 //!     }
 //!

--- a/src/node.rs
+++ b/src/node.rs
@@ -135,8 +135,12 @@ where
             }
             .boxed()
         })?
-        .get("sync_status", |_req, state| {
-            async move { Ok(state.sync_status().await?) }.boxed()
+        .at("sync_status", |_req, state| {
+            async move {
+                let fut = state.read(|state| state.sync_status()).await;
+                Ok(fut.await?)
+            }
+            .boxed()
         })?
         .get("get_header_window", |req, state| {
             async move {

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -29,6 +29,7 @@ use crate::{Header, QueryResult, VidShare};
 use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::From;
+use futures::future::BoxFuture;
 use hotshot_types::traits::node_implementation::NodeType;
 
 #[derive(Derivative, From)]
@@ -55,10 +56,19 @@ pub trait NodeDataSource<Types: NodeType> {
     async fn vid_share<ID>(&self, id: ID) -> QueryResult<VidShare>
     where
         ID: Into<BlockId<Types>> + Send + Sync;
-    async fn sync_status(&self) -> QueryResult<SyncStatus>;
     async fn get_header_window(
         &self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>>;
+
+    /// Search the database for missing objects and generate a report.
+    ///
+    /// The query to find missing objects can be quite expensive while the database is large, but it
+    /// is read-only and thus should not block other operations. This function returns a future
+    /// which runs the bulk of the query and _does not borrow from `self`_. This allows the caller
+    /// to release a lock on the storage layer and run the expensive query asynchronously, while
+    /// other operations, including write that require exclusive access to the API state, are able
+    /// to proceed.
+    async fn sync_status(&self) -> BoxFuture<'static, QueryResult<SyncStatus>>;
 }


### PR DESCRIPTION
This change should reduce the frequency/severity of slow requests due to long queues forming on the lock protecting the API state.

### This PR:
* Uses `at` instead of `get` to manually control locking in request handlers. The changes are focused on requests which might be slow and which don't actually need a lock on the state for their whole duration
* Upgrades all endpoints in the availability API which have a timeout on a `Fetch` so that they don't have a lock while waiting for the timeout
* Refactors the `sync-status` endpoint to make a clone of the SQL client, and run the actual query without borrowing/locking the API state. This allows the (potentially very slow) query to proceed asynchronously from other requests and state updates

