### PR TITLE
Remove manual Vacuum from pruning

### DIFF
--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -361,6 +361,7 @@ where
         let task = {
             BackgroundTask::spawn("pruner", async move {
                 for i in 1.. {
+                    tracing::warn!("starting pruner run {i} ");
                     {
                         let mut storage = fetcher.storage.write().await;
 
@@ -380,7 +381,6 @@ where
                     }
 
                     sleep(cfg.interval()).await;
-                    tracing::warn!("pruner woke up for the {i}th time");
                 }
             })
         };

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -361,9 +361,6 @@ where
         let task = {
             BackgroundTask::spawn("pruner", async move {
                 for i in 1.. {
-                    sleep(cfg.interval()).await;
-                    tracing::warn!("pruner woke up for the {i}th time");
-
                     {
                         let mut storage = fetcher.storage.write().await;
 
@@ -381,6 +378,9 @@ where
                             }
                         }
                     }
+
+                    sleep(cfg.interval()).await;
+                    tracing::warn!("pruner woke up for the {i}th time");
                 }
             })
         };

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -574,10 +574,10 @@ impl PruneStorage for SqlStorage {
         Ok(size as u64)
     }
 
-/// Note: The prune operation may not immediately free up space even after rows are deleted.
-/// This is because a vacuum operation may be necessary to reclaim more space.
-/// PostgreSQL already performs auto vacuuming, so we are not including it here
-/// as running a vacuum operation can be resource-intensive.
+    /// Note: The prune operation may not immediately free up space even after rows are deleted.
+    /// This is because a vacuum operation may be necessary to reclaim more space.
+    /// PostgreSQL already performs auto vacuuming, so we are not including it here
+    /// as running a vacuum operation can be resource-intensive.
 
     async fn prune(&mut self) -> Result<Option<u64>, QueryError> {
         let cfg = self.get_pruning_config().ok_or(QueryError::Error {


### PR DESCRIPTION
- removes manual vacuum as postgres  runs autovacuum daemon by default and vaccumming can be resource intensive
- sleep after each pruner run 