### PR TITLE
Add LIMIT 1 to query

### DIFF
--- a/src/data_source/storage/sql/query/state.rs
+++ b/src/data_source/storage/sql/query/state.rs
@@ -292,7 +292,8 @@ impl<'a> Transaction<'a> {
                         &format!(
                             "SELECT {header_state_commitment_field} AS root_commmitment
                          FROM header
-                         WHERE height = $1"
+                         WHERE height = $1
+                         LIMIT 1"
                         ),
                         [sql_param(&created)],
                     )


### PR DESCRIPTION
This query was observed to be slow (~3s) in Decaf for one DA node. Not 100% sure this is why, but it might be and should be a harmless change