### PR TITLE
Add metrics and tracing logging around SQL transactions

### DIFF
--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     metrics::PrometheusMetrics,
     node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
-    status::StatusDataSource,
+    status::{HasMetrics, StatusDataSource},
     Header, Payload, QueryResult, Transaction, VidShare,
 };
 use async_trait::async_trait;
@@ -270,6 +270,15 @@ where
     }
 }
 
+impl<D, U> HasMetrics for ExtensibleDataSource<D, U>
+where
+    D: HasMetrics,
+{
+    fn metrics(&self) -> &PrometheusMetrics {
+        self.data_source.metrics()
+    }
+}
+
 #[async_trait]
 impl<D, U> StatusDataSource for ExtensibleDataSource<D, U>
 where
@@ -278,10 +287,6 @@ where
 {
     async fn block_height(&self) -> QueryResult<usize> {
         self.data_source.block_height().await
-    }
-
-    fn metrics(&self) -> &PrometheusMetrics {
-        self.data_source.metrics()
     }
 }
 

--- a/src/data_source/metrics.rs
+++ b/src/data_source/metrics.rs
@@ -12,7 +12,11 @@
 
 #![cfg(feature = "metrics-data-source")]
 
-use crate::{metrics::PrometheusMetrics, status::StatusDataSource, QueryError, QueryResult};
+use crate::{
+    metrics::PrometheusMetrics,
+    status::{HasMetrics, StatusDataSource},
+    QueryError, QueryResult,
+};
 use async_trait::async_trait;
 
 /// A minimal data source for the status API provided in this crate, with no persistent storage.
@@ -56,6 +60,12 @@ pub struct MetricsDataSource {
     metrics: PrometheusMetrics,
 }
 
+impl HasMetrics for MetricsDataSource {
+    fn metrics(&self) -> &PrometheusMetrics {
+        &self.metrics
+    }
+}
+
 #[async_trait]
 impl StatusDataSource for MetricsDataSource {
     async fn block_height(&self) -> QueryResult<usize> {
@@ -67,10 +77,6 @@ impl StatusDataSource for MetricsDataSource {
             })?
             .get();
         Ok(last_synced_height)
-    }
-
-    fn metrics(&self) -> &PrometheusMetrics {
-        &self.metrics
     }
 }
 

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -27,7 +27,9 @@ use crate::{
         },
     },
     data_source::{update, VersionedDataSource},
+    metrics::PrometheusMetrics,
     node::{SyncStatus, TimeWindowQueryData, WindowStart},
+    status::HasMetrics,
     types::HeightIndexed,
     ErrorSnafu, Header, MissingSnafu, NotFoundSnafu, Payload, QueryResult, VidCommitment, VidShare,
 };
@@ -115,6 +117,7 @@ where
     Payload<Types>: QueryablePayload<Types>,
 {
     inner: RwLock<FileSystemStorageInner<Types>>,
+    metrics: PrometheusMetrics,
 }
 
 impl<Types: NodeType> PrunerConfig for FileSystemStorage<Types> where
@@ -184,6 +187,7 @@ where
                 block_storage: LedgerLog::create(loader, "blocks", CACHED_BLOCKS_COUNT)?,
                 vid_storage: LedgerLog::create(loader, "vid_common", CACHED_VID_COMMON_COUNT)?,
             }),
+            metrics: Default::default(),
         })
     }
 
@@ -254,6 +258,7 @@ where
                 vid_storage,
                 top_storage: None,
             }),
+            metrics: Default::default(),
         })
     }
 
@@ -713,3 +718,13 @@ where
 }
 
 impl<T: Revert> PrunedHeightStorage for Transaction<T> {}
+
+impl<Types> HasMetrics for FileSystemStorage<Types>
+where
+    Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    fn metrics(&self) -> &PrometheusMetrics {
+        &self.metrics
+    }
+}

--- a/src/data_source/storage/sql/transaction.rs
+++ b/src/data_source/storage/sql/transaction.rs
@@ -143,7 +143,7 @@ impl<Mode: TransactionMode> TransactionMetricsGuard<Mode> {
         }
     }
 
-    fn close(&mut self, t: CloseType) {
+    fn set_closed(&mut self, t: CloseType) {
         self.close_type = t;
     }
 }
@@ -184,13 +184,13 @@ impl<Mode: TransactionMode> Transaction<Mode> {
 impl<Mode: TransactionMode> update::Transaction for Transaction<Mode> {
     async fn commit(mut self) -> anyhow::Result<()> {
         self.inner.commit().await?;
-        self.metrics.close(CloseType::Commit);
+        self.metrics.set_closed(CloseType::Commit);
         Ok(())
     }
     fn revert(mut self) -> impl Future + Send {
         async move {
             self.inner.rollback().await.unwrap();
-            self.metrics.close(CloseType::Revert);
+            self.metrics.set_closed(CloseType::Revert);
         }
     }
 }

--- a/src/status/data_source.rs
+++ b/src/status/data_source.rs
@@ -19,11 +19,13 @@ use async_trait::async_trait;
 use chrono::Utc;
 use hotshot_types::traits::metrics::Metrics;
 
-#[async_trait]
-pub trait StatusDataSource {
-    async fn block_height(&self) -> QueryResult<usize>;
-
+pub trait HasMetrics {
     fn metrics(&self) -> &PrometheusMetrics;
+}
+
+#[async_trait]
+pub trait StatusDataSource: HasMetrics {
+    async fn block_height(&self) -> QueryResult<usize>;
 
     fn consensus_metrics(&self) -> QueryResult<PrometheusMetrics> {
         self.metrics()


### PR DESCRIPTION
If the sqlx changes don't fix the issues we're seeing in devnet, this should help with debugging.

### This PR:
Adds the following metrics:
* `sql_open_transactions`: number of transactions currently open
* `transaction_duration`: histogram of transaction durations
* `committed_transactions`: count of transactions closed by committing
* `reverted_transactions`: count of transactions closed by reverting
* `dropped_transactions`: count of transactions closed by dropping (implicit revert)

Adds trace-level logging for transaction lifecycle