### PR TITLE
Do not store payloads with leaves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3104,14 +3104,13 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "utils",
  "vbs",
 ]
 
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "async-trait",
  "clap",
@@ -3130,7 +3129,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3163,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "hotshot-fakeapi"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3183,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3194,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3279,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3289,13 +3288,12 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
- "utils",
 ]
 
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3325,7 +3323,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "utils",
  "vbs",
  "vec1",
 ]
@@ -3333,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3379,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3431,7 +3428,6 @@ dependencies = [
  "tracing",
  "typenum",
  "url",
- "utils",
  "vbs",
  "vec1",
 ]
@@ -4447,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78-patch4#e8abb17d990560d6c92489522d218b99d2089db3"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -8386,14 +8382,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "utils"
-version = "0.5.78"
-source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
-dependencies = [
- "tracing",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3104,13 +3104,14 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "utils",
  "vbs",
 ]
 
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "async-trait",
  "clap",
@@ -3129,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3162,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "hotshot-fakeapi"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3182,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -3193,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "hotshot-orchestrator"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -3278,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3288,12 +3289,13 @@ dependencies = [
  "futures",
  "tokio",
  "tracing",
+ "utils",
 ]
 
 [[package]]
 name = "hotshot-task-impls"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3323,6 +3325,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "utils",
  "vbs",
  "vec1",
 ]
@@ -3330,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3376,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3428,6 +3431,7 @@ dependencies = [
  "tracing",
  "typenum",
  "url",
+ "utils",
  "vbs",
  "vec1",
 ]
@@ -4443,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "libp2p-networking"
 version = "0.5.78"
-source = "git+https://github.com/EspressoSystems/HotShot.git?tag=0.5.78#be7d9be60abbf8f293b7e95940ff77eff2e0739e"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
 dependencies = [
  "anyhow",
  "async-compatibility-layer",
@@ -8382,6 +8386,14 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utils"
+version = "0.5.78"
+source = "git+https://github.com/EspressoSystems//HotShot.git?branch=main#50fc977fa91b01fd9eacf08f63c57d8bd1546cb3"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,9 @@ derivative = "2.2"
 derive_more = "0.99"
 either = "1.12"
 futures = "0.3"
-hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78" }
-hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78" }
-hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78" }
+hotshot = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch4" }
+hotshot-testing = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch4" }
+hotshot-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch4" }
 itertools = "0.12.1"
 jf-merkle-tree = { version = "0.1.0", git = "https://github.com/EspressoSystems/jellyfish", tag = "0.4.5", features = [
 	"std",
@@ -116,7 +116,7 @@ sqlx = { version = "0.8", features = [
 
 # Dependencies enabled by feature "testing".
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0", optional = true }
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78", optional = true }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch4", optional = true }
 portpicker = { version = "0.1", optional = true }
 rand = { version = "0.8", optional = true }
 spin_sleep = { version = "1.2", optional = true }
@@ -137,15 +137,9 @@ backtrace-on-stack-overflow = { version = "0.3", optional = true }
 clap = { version = "4.5", features = ["derive", "env"] }
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git", tag = "0.1.0" }
 generic-array = "0.14"
-hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems/HotShot.git", tag = "0.5.78-patch4" }
 portpicker = "0.1"
 rand = "0.8"
 reqwest = "0.12.3"
 spin_sleep = "1.2"
 tempfile = "3.10"
-
-[patch."https://github.com/EspressoSystems/HotShot.git"]
-hotshot = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }
-hotshot-testing = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }
-hotshot-types = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }
-hotshot-example-types = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,3 +143,9 @@ rand = "0.8"
 reqwest = "0.12.3"
 spin_sleep = "1.2"
 tempfile = "3.10"
+
+[patch."https://github.com/EspressoSystems/HotShot.git"]
+hotshot = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }
+hotshot-testing = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }
+hotshot-types = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }
+hotshot-example-types = { git = "https://github.com/EspressoSystems//HotShot.git", branch = "main" }

--- a/migrations/V100__drop_leaf_payload.sql
+++ b/migrations/V100__drop_leaf_payload.sql
@@ -1,0 +1,5 @@
+-- A previous version of the software erroneously stored leaves in the database with the full
+-- payload. This is unnecesssary, since we store payloads in their own separate table, and hurts
+-- performance. The updated software no longer does this for new leaves. This migration removes the
+-- redundant payloads for old leaves.
+UPDATE leaf SET leaf = jsonb_set(leaf, '{block_payload}', 'null');

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -210,7 +210,7 @@ impl<Types: NodeType> LeafQueryData<Types> {
     ///
     /// Fails with an [`InconsistentLeafError`] if `qc` does not reference `leaf`.
     pub fn new(
-        leaf: Leaf<Types>,
+        mut leaf: Leaf<Types>,
         qc: QuorumCertificate<Types>,
     ) -> Result<Self, InconsistentLeafError<Types>> {
         // TODO: Replace with the new `commit` function in HotShot. Add an `upgrade_lock` parameter
@@ -224,6 +224,11 @@ impl<Types: NodeType> LeafQueryData<Types> {
                 qc_leaf: qc.data.leaf_commit
             }
         );
+
+        // We only want the leaf for the block header and consensus metadata. The payload will be
+        // stored separately.
+        leaf.unfill_block_payload();
+
         Ok(Self { leaf, qc })
     }
 

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -1348,7 +1348,7 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         match self {
             Ok(t) => Some(t),
             Err(err) => {
-                tracing::warn!(
+                tracing::info!(
                     "error loading resource from local storage, will try to fetch: {err:#}"
                 );
                 None

--- a/src/data_source/sql.rs
+++ b/src/data_source/sql.rs
@@ -150,7 +150,7 @@ impl Config {
 ///
 /// Custom migrations can be inserted using [`Config::migrations`]. Each custom migration will be
 /// inserted into the overall sequence of migrations in order of version number. The migrations
-/// provided by this crate only use version numbers which are multiples of 10, so the non-multiples
+/// provided by this crate only use version numbers which are multiples of 100, so the non-multiples
 /// can be used to insert custom migrations between the default migrations. You can also replace a
 /// default migration completely by providing a custom migration with the same version number. This
 /// may be useful when an earlier custom migration has altered the schema in such a way that a later

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -74,8 +74,9 @@ use self::{migrate::Migrator, transaction::PoolMetrics};
 ///
 /// ```
 /// # use hotshot_query_service::data_source::sql::{include_migrations, Migration};
-/// let migrations: Vec<Migration> =
+/// let mut migrations: Vec<Migration> =
 ///     include_migrations!("$CARGO_MANIFEST_DIR/migrations").collect();
+/// migrations.sort();
 /// assert_eq!(migrations[0].version(), 10);
 /// assert_eq!(migrations[0].name(), "init_schema");
 /// ```

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -120,12 +120,22 @@ pub fn default_migrations() -> Vec<Migration> {
     // Check version uniqueness and sort by version.
     validate_migrations(&mut migrations).expect("default migrations are invalid");
 
-    // Check that all migration versions are multiples of 10, so that custom migrations can be
+    // Check that all migration versions are multiples of 100, so that custom migrations can be
     // inserted in between.
     for m in &migrations {
-        if m.version() == 0 || m.version() % 10 != 0 {
-            panic!(
-                "default migration version {} is not a positive multiple of 10",
+        if m.version() <= 30 {
+            // An older version of this software used intervals of 10 instead of 100. This was
+            // changed to allow more custom migrations between each default migration, but we must
+            // still accept older migrations that followed the older rule.
+            assert!(
+                m.version() > 0 && m.version() % 10 == 0,
+                "legacy default migration version {} is not a positive multiple of 10",
+                m.version()
+            );
+        } else {
+            assert!(
+                m.version() % 100 == 0,
+                "default migration version {} is not a multiple of 100",
                 m.version()
             );
         }
@@ -946,11 +956,11 @@ mod test {
         // The SQL commands used here will fail if not run in order.
         let migrations = vec![
             Migration::unapplied(
-                "V33__create_test_table.sql",
+                "V103__create_test_table.sql",
                 "ALTER TABLE test ADD COLUMN data INTEGER;",
             )
             .unwrap(),
-            Migration::unapplied("V32__create_test_table.sql", "CREATE TABLE test ();").unwrap(),
+            Migration::unapplied("V102__create_test_table.sql", "CREATE TABLE test ();").unwrap(),
         ];
         connect(true, migrations.clone()).await.unwrap();
 


### PR DESCRIPTION
### This PR:
* Fixes a bug where we might store a leaf with the full block payload, which is redundant because the payload is already stored separately
* Adds a migration to remove payloads from existing leaves
* Changes the spacing between default migrations from 10 to 100 to allow more room for intermediate migrations in the sequencer repo, since we already have 10 migrations there since the last query service migration
