### PR TITLE
fix order by clause in getTransactionDetail query

### DIFF
--- a/src/data_source/storage/sql/queries/explorer.rs
+++ b/src/data_source/storage/sql/queries/explorer.rs
@@ -382,7 +382,7 @@ where
                 }),
             ),
             TransactionIdentifier::HeightAndOffset(height, offset) => {
-                txns.into_iter().enumerate().rev().nth(offset).ok_or(
+                txns.into_iter().enumerate().nth(offset).ok_or(
                     GetTransactionDetailError::TransactionNotFound(NotFound {
                         key: format!("at {height} and {offset}"),
                     }),

--- a/src/data_source/storage/sql/queries/explorer.rs
+++ b/src/data_source/storage/sql/queries/explorer.rs
@@ -346,7 +346,7 @@ where
                         SELECT t1.block_height
                             FROM transaction AS t1
                             WHERE t1.block_height = {}
-                            ORDER BY (t1.block_height, t1.index) DESC
+                            ORDER BY (t1.block_height, t1.index)
                             OFFSET {}
                             LIMIT 1
                     )


### PR DESCRIPTION
addresses https://github.com/EspressoSystems/hotshot-query-service/issues/721

The PR fixes the order by clause for transaction detail query. 

using ORDER BY DESC with an offset caused skipping of recent transactions, resulting in (N - offset)th transaction. This PR changes DESC to ASC  so that older transactions are correctly skipped