### PR TITLE
Remove unused Default bound on InstanceState

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ on:
       - main
       - release-*
   pull_request:
-    branches:
-      - main
-      - release-*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,6 @@ on:
       - main
       - release-*
   pull_request:
-    branches:
-      - main
-      - release-*
   workflow_dispatch:
 
 jobs:

--- a/src/data_source/update.rs
+++ b/src/data_source/update.rs
@@ -70,7 +70,6 @@ impl<Types: NodeType, T> UpdateDataSource<Types> for T
 where
     T: UpdateAvailabilityData<Types> + Send + Sync,
     Payload<Types>: QueryablePayload<Types>,
-    <Types as NodeType>::InstanceState: Default,
 {
     async fn update(&self, event: &Event<Types>) -> Result<(), u64> {
         if let EventType::Decide { leaf_chain, qc, .. } = &event.event {
@@ -154,10 +153,7 @@ where
 
 fn genesis_vid<Types: NodeType>(
     leaf: &Leaf<Types>,
-) -> anyhow::Result<(VidCommonQueryData<Types>, VidShare)>
-where
-    <Types as NodeType>::InstanceState: Default,
-{
+) -> anyhow::Result<(VidCommonQueryData<Types>, VidShare)> {
     let payload = Payload::<Types>::empty().0;
     let bytes = payload.encode();
     let mut disperse = vid_scheme(GENESIS_VID_NUM_STORAGE_NODES)


### PR DESCRIPTION
In the sequencer repo we don't have a proper `Default` impl but one that's gated behind the testing feature because it wouldn't actually work.

Working on
https://github.com/EspressoSystems/espresso-sequencer/pull/2283 it seems that this is one of the pain points for removing the spread of the testing features in the sequencer crates.

It looks like we don't need the trait bound anymore in the query service.