### PR TITLE
Improve efficiency of aggregated statistics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Format Check
         run: cargo fmt -- --check
 
-      # Run Clippy on all targets. The lint workflow doesn't run Clippy on testgs, because the tests
+      # Run Clippy on all targets. The lint workflow doesn't run Clippy on tests, because the tests
       # don't compile with all combinations of features.
       - name: Clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Format Check
         run: cargo fmt -- --check
 
-      # Run Clippy on all targets. The lint workflow doesn't run Clippy on tests, because the tests
+      # Run Clippy on all targets. The lint workflow doesn't run Clippy on testgs, because the tests
       # don't compile with all combinations of features.
       - name: Clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
@@ -47,6 +47,9 @@ jobs:
         run: |
           cargo nextest run --workspace --release --all-features
         timeout-minutes: 60
+
+      - name: Doc Test
+        run: cargo test --release --all-features --doc
         
       - name: Generate Documentation
         run: |

--- a/api/node.toml
+++ b/api/node.toml
@@ -34,21 +34,33 @@ Returns an integer.
 """
 
 [route.count_transactions]
-PATH = ["transactions/count"]
+PATH = ["transactions/count", "transactions/count/:to", "transactions/count/:from/:to"]
+":from" = "Integer"
+":to" = "Integer"
 DOC = """
 Get the number of transactions in the chain.
 
-Warning: count may be low if data is currently being indexed (see `sync-status`).
+If `:from` or `:to` is specified, they restrict the range of blocks considered.
+`transactions/count/:to` will return the number of transactions in all blocks up to and including
+block number `:to`, while `transactions/count/:from/:to` will count the transactions in all blocks
+between `:from` (inclusive) and `:to` (inclusive).
 
 Returns an integer.
 """
 
 [route.payload_size]
-PATH = ["payloads/total-size"]
+PATH = ["payloads/size", "payloads/size/:to", "payloads/size/:from/:to", "payloads/total-size"]
+":from" = "Integer"
+":to" = "Integer"
 DOC = """
 Get the size (in bytes) of all payload data in the chain.
 
-Warning: size may be low if data is currently being indexed (see `sync-status`).
+If `:from` or `:to` is specified, they restrict the range of blocks considered. `payloads/size/:to`
+will return the cumulative size of all payloads in blocks up to and including block number `:to`,
+while `payloads/size/:from/:to` will return the cumulative size in all blocks between `:from`
+(inclusive) and `:to` (inclusive).
+
+`payloads/total-size` is a deprecated alias for `payloads/size`.
 
 Returns an integer.
 """

--- a/migrations/V200__create_aggregates_table.sql
+++ b/migrations/V200__create_aggregates_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE aggregate (
+    height BIGINT PRIMARY KEY REFERENCES header (height) ON DELETE CASCADE,
+    num_transactions BIGINT NOT NULL,
+    payload_size BIGINT NOT NULL
+);

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -234,11 +234,17 @@ where
     async fn block_height(&self) -> QueryResult<usize> {
         self.data_source.block_height().await
     }
-    async fn count_transactions(&self) -> QueryResult<usize> {
-        self.data_source.count_transactions().await
+    async fn count_transactions_in_range(
+        &self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize> {
+        self.data_source.count_transactions_in_range(range).await
     }
-    async fn payload_size(&self) -> QueryResult<usize> {
-        self.data_source.payload_size().await
+    async fn payload_size_in_range(
+        &self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize> {
+        self.data_source.payload_size_in_range(range).await
     }
     async fn vid_share<ID>(&self, id: ID) -> QueryResult<VidShare>
     where

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -77,8 +77,8 @@ use super::{
     notifier::Notifier,
     storage::{
         pruning::{PruneStorage, PrunedHeightStorage},
-        AvailabilityStorage, ExplorerStorage, MerklizedStateHeightStorage, MerklizedStateStorage,
-        NodeStorage, UpdateAvailabilityStorage,
+        AggregatesStorage, AvailabilityStorage, ExplorerStorage, MerklizedStateHeightStorage,
+        MerklizedStateStorage, NodeStorage, UpdateAggregatesStorage, UpdateAvailabilityStorage,
     },
     Transaction, VersionedDataSource,
 };
@@ -153,6 +153,7 @@ pub struct Builder<Types, S, P> {
     active_fetch_delay: Duration,
     chunk_fetch_delay: Duration,
     proactive_fetching: bool,
+    aggregator: bool,
     _types: PhantomData<Types>,
 }
 
@@ -187,6 +188,7 @@ impl<Types, S, P> Builder<Types, S, P> {
             active_fetch_delay: Duration::from_millis(50),
             chunk_fetch_delay: Duration::from_millis(100),
             proactive_fetching: true,
+            aggregator: true,
             _types: Default::default(),
         }
     }
@@ -320,6 +322,15 @@ impl<Types, S, P> Builder<Types, S, P> {
         self.proactive_fetching = false;
         self
     }
+
+    /// Run without an aggregator.
+    ///
+    /// This can reduce load on the CPU and the database, but it will cause aggregate statistics
+    /// (such as transaction counts) not to update.
+    pub fn disable_aggregator(mut self) -> Self {
+        self.aggregator = false;
+        self
+    }
 }
 
 impl<Types, S, P> Builder<Types, S, P>
@@ -328,8 +339,9 @@ where
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: QueryableHeader<Types>,
     S: PruneStorage + VersionedDataSource + HasMetrics + 'static,
-    for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + PrunedHeightStorage + NodeStorage<Types>,
-    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+    for<'a> S::ReadOnly<'a>:
+        AvailabilityStorage<Types> + PrunedHeightStorage + NodeStorage<Types> + AggregatesStorage,
+    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types> + UpdateAggregatesStorage<Types>,
     P: AvailabilityProvider<Types>,
 {
     /// Build a [`FetchingDataSource`] with these options.
@@ -367,6 +379,8 @@ where
     fetcher: Arc<Fetcher<Types, S, P>>,
     // The proactive scanner task. This is only saved here so that we can cancel it on drop.
     scanner: Option<BackgroundTask>,
+    // The aggregator task, which derives aggregate statistics from a block stream.
+    aggregator: Option<BackgroundTask>,
     pruner: Pruner<Types, S, P>,
 }
 
@@ -419,8 +433,9 @@ where
     Payload<Types>: QueryablePayload<Types>,
     Header<Types>: QueryableHeader<Types>,
     S: VersionedDataSource + PruneStorage + HasMetrics + 'static,
-    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
-    for<'a> S::ReadOnly<'a>: AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage,
+    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types> + UpdateAggregatesStorage<Types>,
+    for<'a> S::ReadOnly<'a>:
+        AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage + AggregatesStorage,
     P: AvailabilityProvider<Types>,
 {
     /// Build a [`FetchingDataSource`] with the given `storage` and `provider`.
@@ -429,6 +444,7 @@ where
     }
 
     async fn new(builder: Builder<Types, S, P>) -> anyhow::Result<Self> {
+        let aggregator = builder.aggregator;
         let proactive_fetching = builder.proactive_fetching;
         let minor_interval = builder.minor_scan_interval;
         let major_interval = builder.major_scan_interval;
@@ -437,6 +453,7 @@ where
             .proactive_range_chunk_size
             .unwrap_or(builder.range_chunk_size);
         let scanner_metrics = ScannerMetrics::new(builder.storage.metrics());
+        let aggregator_metrics = AggregatorMetrics::new(builder.storage.metrics());
 
         let fetcher = Arc::new(Fetcher::new(builder).await?);
         let scanner = if proactive_fetching {
@@ -454,11 +471,21 @@ where
             None
         };
 
+        let aggregator = if aggregator {
+            Some(BackgroundTask::spawn(
+                "aggregator",
+                fetcher.clone().aggregate(aggregator_metrics),
+            ))
+        } else {
+            None
+        };
+
         let pruner = Pruner::new(fetcher.clone()).await;
         let ds = Self {
             fetcher,
             scanner,
             pruner,
+            aggregator,
         };
 
         Ok(ds)
@@ -1169,6 +1196,70 @@ where
 impl<Types, S, P> Fetcher<Types, S, P>
 where
     Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+    S: VersionedDataSource + 'static,
+    for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types> + UpdateAggregatesStorage<Types>,
+    for<'a> S::ReadOnly<'a>:
+        AvailabilityStorage<Types> + NodeStorage<Types> + PrunedHeightStorage + AggregatesStorage,
+    P: AvailabilityProvider<Types>,
+{
+    #[tracing::instrument(skip_all)]
+    async fn aggregate(self: Arc<Self>, metrics: AggregatorMetrics) {
+        loop {
+            let start = loop {
+                let mut tx = match self.read().await {
+                    Ok(tx) => tx,
+                    Err(err) => {
+                        tracing::error!("unable to start aggregator: {err:#}");
+                        sleep(Duration::from_secs(5)).await;
+                        continue;
+                    }
+                };
+                match tx.aggregates_height().await {
+                    Ok(height) => break height,
+                    Err(err) => {
+                        tracing::error!("unable to load aggregator height: {err:#}");
+                        sleep(Duration::from_secs(5)).await;
+                        continue;
+                    }
+                };
+            };
+            tracing::info!(start, "starting aggregator");
+            metrics.height.set(start);
+
+            let mut blocks = self.clone().get_range::<_, BlockQueryData<Types>>(start..);
+            while let Some(block) = blocks.next().await {
+                let block = block.await;
+                let height = block.height();
+                tracing::debug!(height, "updating aggregate statistics for block");
+                loop {
+                    let res = async {
+                        let mut tx = self.write().await.context("opening transaction")?;
+                        tx.update_aggregates(&block).await?;
+                        tx.commit().await.context("committing transaction")
+                    }
+                    .await;
+                    match res {
+                        Ok(()) => break,
+                        Err(err) => {
+                            tracing::warn!(
+                                height,
+                                "failed to update aggregates for block: {err:#}"
+                            );
+                            sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+                metrics.height.set(height as usize);
+            }
+            tracing::warn!("aggregator block stream ended unexpectedly; will restart");
+        }
+    }
+}
+
+impl<Types, S, P> Fetcher<Types, S, P>
+where
+    Types: NodeType,
     S: VersionedDataSource,
     for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
 {
@@ -1366,18 +1457,24 @@ where
         tx.block_height().await
     }
 
-    async fn count_transactions(&self) -> QueryResult<usize> {
+    async fn count_transactions_in_range(
+        &self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize> {
         let mut tx = self.read().await.map_err(|err| QueryError::Error {
             message: err.to_string(),
         })?;
-        tx.count_transactions().await
+        tx.count_transactions_in_range(range).await
     }
 
-    async fn payload_size(&self) -> QueryResult<usize> {
+    async fn payload_size_in_range(
+        &self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize> {
         let mut tx = self.read().await.map_err(|err| QueryError::Error {
             message: err.to_string(),
         })?;
-        tx.payload_size().await
+        tx.payload_size_in_range(range).await
     }
 
     async fn vid_share<ID>(&self, id: ID) -> QueryResult<VidShare>
@@ -1766,6 +1863,21 @@ impl ScannerMetrics {
             self.major_missing_vid.set(missing);
         } else {
             self.minor_missing_vid.update(missing as i64);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AggregatorMetrics {
+    /// The block height for which aggregate statistics are currently available.
+    height: Box<dyn Gauge>,
+}
+
+impl AggregatorMetrics {
+    fn new(metrics: &PrometheusMetrics) -> Self {
+        let group = metrics.subgroup("aggregator".into());
+        Self {
+            height: group.create_gauge("height".into(), None),
         }
     }
 }

--- a/src/data_source/fs.rs
+++ b/src/data_source/fs.rs
@@ -93,7 +93,6 @@ pub use super::storage::fs::Transaction;
 /// synchronize all persistent storage.
 ///
 /// ```
-/// # use async_std::{sync::{Arc, RwLock}, task::spawn};
 /// # use atomic_store::{AtomicStore, AtomicStoreLoader};
 /// # use futures::StreamExt;
 /// # use hotshot::types::SystemContextHandle;
@@ -106,8 +105,9 @@ pub use super::storage::fs::Transaction;
 /// #   MockNodeImpl as AppNodeImpl, MockTypes as AppTypes, MockVersions as AppVersions
 /// # };
 /// # use hotshot_example_types::node_types::TestVersions;
-/// # use std::path::Path;
+/// # use std::{path::Path, sync::Arc};
 /// # use tide_disco::App;
+/// # use tokio::{spawn, sync::RwLock};
 /// # use vbs::version::StaticVersionType;
 /// struct AppState {
 ///     // Top-level storage coordinator

--- a/src/data_source/sql.rs
+++ b/src/data_source/sql.rs
@@ -228,7 +228,6 @@ impl Config {
 /// the steps in [custom migrations](#custom-migrations) to accomodate this.
 ///
 /// ```
-/// # use async_std::{sync::Arc, task::spawn};
 /// # use futures::StreamExt;
 /// # use hotshot::types::SystemContextHandle;
 /// # use hotshot_query_service::Error;
@@ -240,7 +239,9 @@ impl Config {
 /// #   MockNodeImpl as AppNodeImpl, MockTypes as AppTypes, MockVersions as AppVersions
 /// # };
 /// # use hotshot_example_types::node_types::TestVersions;
+/// # use std::sync::Arc;
 /// # use tide_disco::App;
+/// # use tokio::spawn;
 /// # use vbs::version::StaticVersionType;
 /// struct AppState {
 ///     hotshot_qs: SqlDataSource<AppTypes, NoFetching>,

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -181,8 +181,14 @@ where
 #[async_trait]
 pub trait NodeStorage<Types: NodeType> {
     async fn block_height(&mut self) -> QueryResult<usize>;
-    async fn count_transactions(&mut self) -> QueryResult<usize>;
-    async fn payload_size(&mut self) -> QueryResult<usize>;
+    async fn count_transactions_in_range(
+        &mut self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize>;
+    async fn payload_size_in_range(
+        &mut self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize>;
     async fn vid_share<ID>(&mut self, id: ID) -> QueryResult<VidShare>
     where
         ID: Into<BlockId<Types>> + Send + Sync;
@@ -194,6 +200,22 @@ pub trait NodeStorage<Types: NodeType> {
 
     /// Search the database for missing objects and generate a report.
     async fn sync_status(&mut self) -> QueryResult<SyncStatus>;
+}
+
+pub trait AggregatesStorage {
+    /// The block height for which aggregate statistics are currently available.
+    fn aggregates_height(&mut self) -> impl Future<Output = anyhow::Result<usize>> + Send;
+}
+
+pub trait UpdateAggregatesStorage<Types>
+where
+    Types: NodeType,
+{
+    /// Update aggregate statistics based on a new block.
+    fn update_aggregates(
+        &mut self,
+        block: &BlockQueryData<Types>,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
 /// An interface for querying Data and Statistics from the HotShot Blockchain.

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -963,11 +963,11 @@ mod test {
         // The SQL commands used here will fail if not run in order.
         let migrations = vec![
             Migration::unapplied(
-                "V103__create_test_table.sql",
+                "V999__create_test_table.sql",
                 "ALTER TABLE test ADD COLUMN data INTEGER;",
             )
             .unwrap(),
-            Migration::unapplied("V102__create_test_table.sql", "CREATE TABLE test ();").unwrap(),
+            Migration::unapplied("V998__create_test_table.sql", "CREATE TABLE test ();").unwrap(),
         ];
         connect(true, migrations.clone()).await.unwrap();
 

--- a/src/data_source/storage/sql/queries/explorer.rs
+++ b/src/data_source/storage/sql/queries/explorer.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     availability::{BlockQueryData, QueryableHeader, QueryablePayload, TransactionIndex},
-    data_source::storage::ExplorerStorage,
+    data_source::storage::{ExplorerStorage, NodeStorage},
     explorer::{
         self,
         errors::{self, NotFound},
@@ -459,24 +459,9 @@ where
         };
 
         let genesis_overview = {
-            let row = query(
-                "SELECT
-                    (SELECT MAX(height) + 1 FROM header) AS blocks,
-                    (SELECT COUNT(*) FROM transaction) AS transactions",
-            )
-            .fetch_one(self.as_mut())
-            .await?;
-
-            let blocks: i64 = row.try_get("blocks")?;
-            let transactions: i64 = row.try_get("transactions")?;
-
-            let blocks: u64 = blocks
-                .try_into()
-                .decode_error("failed to convert blocks to u64 {e}")?;
-            let transactions: u64 = transactions
-                .try_into()
-                .decode_error("failed to convert transactions to u64 {e}")?;
-
+            let blocks = NodeStorage::<Types>::block_height(self).await? as u64;
+            let transactions =
+                NodeStorage::<Types>::count_transactions_in_range(self, ..).await? as u64;
             GenesisOverview {
                 rollups: 0,
                 transactions,

--- a/src/fetching/provider/query_service.rs
+++ b/src/fetching/provider/query_service.rs
@@ -1088,6 +1088,7 @@ mod test {
         let storage = FailStorage::from(SqlStorage::connect(db.config()).await.unwrap());
         let data_source = FetchingDataSource::builder(storage, provider)
             .disable_proactive_fetching()
+            .disable_aggregator()
             .with_max_retry_interval(Duration::from_millis(100))
             .with_retry_timeout(Duration::from_secs(1))
             .build()
@@ -1173,6 +1174,7 @@ mod test {
         let storage = FailStorage::from(SqlStorage::connect(db.config()).await.unwrap());
         let data_source = FetchingDataSource::builder(storage, provider)
             .disable_proactive_fetching()
+            .disable_aggregator()
             .with_min_retry_interval(Duration::from_millis(100))
             .build()
             .await

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -30,6 +30,7 @@ use async_trait::async_trait;
 use derivative::Derivative;
 use derive_more::From;
 use hotshot_types::traits::node_implementation::NodeType;
+use std::ops::RangeBounds;
 
 #[derive(Derivative, From)]
 #[derivative(Copy(bound = ""), Debug(bound = ""))]
@@ -50,8 +51,14 @@ impl<Types: NodeType> Clone for WindowStart<Types> {
 #[async_trait]
 pub trait NodeDataSource<Types: NodeType> {
     async fn block_height(&self) -> QueryResult<usize>;
-    async fn count_transactions(&self) -> QueryResult<usize>;
-    async fn payload_size(&self) -> QueryResult<usize>;
+    async fn count_transactions_in_range(
+        &self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize>;
+    async fn payload_size_in_range(
+        &self,
+        range: impl RangeBounds<usize> + Send,
+    ) -> QueryResult<usize>;
     async fn vid_share<ID>(&self, id: ID) -> QueryResult<VidShare>
     where
         ID: Into<BlockId<Types>> + Send + Sync;
@@ -63,4 +70,12 @@ pub trait NodeDataSource<Types: NodeType> {
 
     /// Search the database for missing objects and generate a report.
     async fn sync_status(&self) -> QueryResult<SyncStatus>;
+
+    async fn count_transactions(&self) -> QueryResult<usize> {
+        self.count_transactions_in_range(0..).await
+    }
+
+    async fn payload_size(&self) -> QueryResult<usize> {
+        self.payload_size_in_range(0..).await
+    }
 }


### PR DESCRIPTION
We have some statistics that are derived from the entire block history, namely transaction count and payload size. Previously, these were computed on the fly each request, which requires an expensive full table scan and, in the case of payload size, a large sum. We saw this causing performance problems on decaf and mainnet, particularly the block explorer, which uses these statistics heavily

### This PR:

Adds a new table `aggregate`, which stores these cumulative values _at each block height_. This table is kept up to date by a background task scanning the block stream. Now, looking up the values of these statistics just requires reading a single row in this table. This approach has numerous benefits in addition to a massive performance improvement:
* we can now easily look up the values of these statistics at any historical block height, or for any historical _range_ of blocks
* instead of returning inaccurate counts when data is missing, we will simply return that we don't have the counts yet for the requested block height, since the aggregate table won't be populated for that row
* requests that explicitly specify a range or upper bound are easily cachable
