### PR TITLE
Fix multi-column ORDER BY clauses

### DIFF
--- a/src/data_source/storage/sql/queries/availability.rs
+++ b/src/data_source/storage/sql/queries/availability.rs
@@ -226,7 +226,7 @@ where
                 JOIN payload AS p ON h.height = p.height
                 JOIN transaction AS t ON t.block_height = h.height
                 WHERE t.hash = {hash_param}
-                ORDER BY (t.block_height, t.index) ASC
+                ORDER BY t.block_height, t.index
                 LIMIT 1"
         );
         let row = query.query(&sql).fetch_one(self.as_mut()).await?;

--- a/src/data_source/storage/sql/queries/explorer.rs
+++ b/src/data_source/storage/sql/queries/explorer.rs
@@ -217,14 +217,14 @@ where
         // returned results based on.
         let transaction_target_query = match target {
             TransactionIdentifier::Latest => query(
-                "SELECT t.block_height AS height, t.index AS index FROM transaction AS t ORDER BY (t.block_height, t.index) DESC LIMIT 1",
+                "SELECT t.block_height AS height, t.index AS index FROM transaction AS t ORDER BY t.block_height DESC, t.index DESC LIMIT 1",
             ),
             TransactionIdentifier::HeightAndOffset(height, _) => query(
-                "SELECT t.block_height AS height, t.index AS index FROM transaction AS t WHERE t.block_height = $1 ORDER BY (t.block_height, t.index) DESC LIMIT 1",
+                "SELECT t.block_height AS height, t.index AS index FROM transaction AS t WHERE t.block_height = $1 ORDER BY t.block_height DESC, t.index DESC LIMIT 1",
             )
             .bind(*height as i64),
             TransactionIdentifier::Hash(hash) => query(
-                "SELECT t.block_height AS height, t.index AS index FROM transaction AS t WHERE t.hash = $1 ORDER BY (t.block_height, t.index) DESC LIMIT 1",
+                "SELECT t.block_height AS height, t.index AS index FROM transaction AS t WHERE t.hash = $1 ORDER BY t.block_height DESC, t.index DESC LIMIT 1",
             )
             .bind(hash.to_string()),
         };
@@ -264,7 +264,7 @@ where
                             SELECT t.block_height
                                 FROM transaction AS t
                                 WHERE (t.block_height, t.index) <= ({}, {})
-                                ORDER BY (t.block_height, t.index) DESC
+                                ORDER BY t.block_height DESC, t.index DESC
                                 LIMIT {}
                         )
                         ORDER BY h.height DESC",
@@ -350,7 +350,7 @@ where
                         SELECT t1.block_height
                             FROM transaction AS t1
                             WHERE t1.block_height = {}
-                            ORDER BY (t1.block_height, t1.index)
+                            ORDER BY t1.block_height, t1.index
                             OFFSET {}
                             LIMIT 1
                     )
@@ -366,7 +366,7 @@ where
                         SELECT t1.block_height
                             FROM transaction AS t1
                             WHERE t1.hash = {}
-                            ORDER BY (t1.block_height, t1.index) DESC
+                            ORDER BY t1.block_height DESC, t1.index DESC
                             LIMIT 1
                     )
                     ORDER BY h.height DESC",


### PR DESCRIPTION
Postgres treats `ORDER BY (col1, col2) [DESC]` _very_ differently from `ORDER BY col1 [DESC], col2 [DESC]`. If there is a multi-column index on `(col1, col2)`, only the latter (without parentheses) will use the index. This is causing some extremely slow queries on Decaf and Mainnet, particularly in the block explorer; these are queries which should be almost trivial.

This may overlap a bit with work done in #728 , however this PR is specifically meant to address this issue exhaustively, and to be standalone, so hopefully we can merge this very quickly, as it's a huge performance improvement.

### This PR:
This changes fixes every occurence of these type of queries.

