### PR TITLE
Avoid unnecessary loading of full payloads and VID common

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Espresso Systems (espressosys.com)
+# This file is part of the HotShot Query Service library.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+# General Public License as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program. If not,
+# see <https://www.gnu.org/licenses/>.
+
+[test-groups]
+sql = { max-threads = 2 }
+
+[[profile.default.overrides]]
+filter = 'test(sql) | test(query_service) | test(no_storage)'
+test-group = 'sql'

--- a/migrations/V300__transactions_count.sql
+++ b/migrations/V300__transactions_count.sql
@@ -1,0 +1,11 @@
+ALTER TABLE payload
+    ADD COLUMN num_transactions INTEGER;
+
+-- Initialize the `num_transactions` column by counting transactions for each
+-- existing payload.
+UPDATE payload AS p
+    SET (num_transactions) =
+        (SELECT count(*) FROM transaction AS t where t.block_height = p.height)
+    -- Don't set `num_transactions` (leave it NULL) for payloads we don't have
+    -- yet.
+    WHERE p.data IS NOT NULL;

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -641,3 +641,79 @@ where
         }
     }
 }
+
+/// A summary of a payload without all the data.
+///
+/// This type is useful when you only want information about a payload, such as its size or
+/// transaction count, but you don't want to load the entire payload, which might be very large.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PayloadMetadata<Types>
+where
+    Types: NodeType,
+{
+    pub height: u64,
+    pub block_hash: BlockHash<Types>,
+    pub hash: VidCommitment,
+    pub size: u64,
+    pub num_transactions: u64,
+}
+
+impl<Types> HeightIndexed for PayloadMetadata<Types>
+where
+    Types: NodeType,
+{
+    fn height(&self) -> u64 {
+        self.height
+    }
+}
+
+impl<Types> From<BlockQueryData<Types>> for PayloadMetadata<Types>
+where
+    Types: NodeType,
+{
+    fn from(block: BlockQueryData<Types>) -> Self {
+        Self {
+            height: block.height(),
+            block_hash: block.hash(),
+            hash: block.payload_hash(),
+            size: block.size(),
+            num_transactions: block.num_transactions(),
+        }
+    }
+}
+
+/// A summary of a VID payload without all the data.
+///
+/// This is primarily useful when you want to check if a VID object exists, but not load the whole
+/// object.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VidCommonMetadata<Types>
+where
+    Types: NodeType,
+{
+    pub height: u64,
+    pub block_hash: BlockHash<Types>,
+    pub payload_hash: VidCommitment,
+}
+
+impl<Types> HeightIndexed for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+{
+    fn height(&self) -> u64 {
+        self.height
+    }
+}
+
+impl<Types> From<VidCommonQueryData<Types>> for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+{
+    fn from(common: VidCommonQueryData<Types>) -> Self {
+        Self {
+            height: common.height(),
+            block_hash: common.block_hash(),
+            payload_hash: common.payload_hash(),
+        }
+    }
+}

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -14,8 +14,8 @@ use super::VersionedDataSource;
 use crate::{
     availability::{
         AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, LeafId, LeafQueryData,
-        PayloadQueryData, QueryableHeader, QueryablePayload, TransactionHash, TransactionQueryData,
-        UpdateAvailabilityData, VidCommonQueryData,
+        PayloadMetadata, PayloadQueryData, QueryableHeader, QueryablePayload, TransactionHash,
+        TransactionQueryData, UpdateAvailabilityData, VidCommonMetadata, VidCommonQueryData,
     },
     explorer::{self, ExplorerDataSource, ExplorerHeader, ExplorerTransaction},
     merklized_state::{
@@ -153,7 +153,13 @@ where
     type PayloadRange<R> = D::PayloadRange<R>
     where
         R: RangeBounds<usize> + Send;
+    type PayloadMetadataRange<R> = D::PayloadMetadataRange<R>
+    where
+        R: RangeBounds<usize> + Send;
     type VidCommonRange<R> = D::VidCommonRange<R>
+    where
+        R: RangeBounds<usize> + Send;
+    type VidCommonMetadataRange<R> = D::VidCommonMetadataRange<R>
     where
         R: RangeBounds<usize> + Send;
 
@@ -175,11 +181,23 @@ where
     {
         self.data_source.get_payload(id).await
     }
+    async fn get_payload_metadata<ID>(&self, id: ID) -> Fetch<PayloadMetadata<Types>>
+    where
+        ID: Into<BlockId<Types>> + Send + Sync,
+    {
+        self.data_source.get_payload_metadata(id).await
+    }
     async fn get_vid_common<ID>(&self, id: ID) -> Fetch<VidCommonQueryData<Types>>
     where
         ID: Into<BlockId<Types>> + Send + Sync,
     {
         self.data_source.get_vid_common(id).await
+    }
+    async fn get_vid_common_metadata<ID>(&self, id: ID) -> Fetch<VidCommonMetadata<Types>>
+    where
+        ID: Into<BlockId<Types>> + Send + Sync,
+    {
+        self.data_source.get_vid_common_metadata(id).await
     }
     async fn get_leaf_range<R>(&self, range: R) -> Self::LeafRange<R>
     where
@@ -199,11 +217,23 @@ where
     {
         self.data_source.get_payload_range(range).await
     }
+    async fn get_payload_metadata_range<R>(&self, range: R) -> Self::PayloadMetadataRange<R>
+    where
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        self.data_source.get_payload_metadata_range(range).await
+    }
     async fn get_vid_common_range<R>(&self, range: R) -> Self::VidCommonRange<R>
     where
         R: RangeBounds<usize> + Send + 'static,
     {
         self.data_source.get_vid_common_range(range).await
+    }
+    async fn get_vid_common_metadata_range<R>(&self, range: R) -> Self::VidCommonMetadataRange<R>
+    where
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        self.data_source.get_vid_common_metadata_range(range).await
     }
     async fn get_transaction(
         &self,

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -157,6 +157,7 @@ pub struct Builder<Types, S, P> {
     chunk_fetch_delay: Duration,
     proactive_fetching: bool,
     aggregator: bool,
+    aggregator_chunk_size: Option<usize>,
     _types: PhantomData<Types>,
 }
 
@@ -192,6 +193,7 @@ impl<Types, S, P> Builder<Types, S, P> {
             chunk_fetch_delay: Duration::from_millis(100),
             proactive_fetching: true,
             aggregator: true,
+            aggregator_chunk_size: None,
             _types: Default::default(),
         }
     }
@@ -278,7 +280,7 @@ impl<Types, S, P> Builder<Types, S, P> {
     ///
     /// This is similar to [`Self::with_range_chunk_size`], but only affects the chunk size for
     /// proactive fetching scans, not for normal subscription streams. This can be useful to tune
-    /// the proactive scanner to be more or less greedy with the lock on persistent storage.
+    /// the proactive scanner to be more or less greedy with persistent storage resources.
     ///
     /// By default (i.e. if this method is not called) the proactive range chunk size will be set to
     /// whatever the normal range chunk size is.
@@ -332,6 +334,19 @@ impl<Types, S, P> Builder<Types, S, P> {
     /// (such as transaction counts) not to update.
     pub fn disable_aggregator(mut self) -> Self {
         self.aggregator = false;
+        self
+    }
+
+    /// Set the number of items to process at a time when computing aggregate statistics.
+    ///
+    /// This is similar to [`Self::with_range_chunk_size`], but only affects the chunk size for
+    /// the aggregator task, not for normal subscription streams. This can be useful to tune
+    /// the aggregator to be more or less greedy with persistent storage resources.
+    ///
+    /// By default (i.e. if this method is not called) the proactive range chunk size will be set to
+    /// whatever the normal range chunk size is.
+    pub fn with_aggregator_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.aggregator_chunk_size = Some(chunk_size);
         self
     }
 }
@@ -448,6 +463,9 @@ where
 
     async fn new(builder: Builder<Types, S, P>) -> anyhow::Result<Self> {
         let aggregator = builder.aggregator;
+        let aggregator_chunk_size = builder
+            .aggregator_chunk_size
+            .unwrap_or(builder.range_chunk_size);
         let proactive_fetching = builder.proactive_fetching;
         let minor_interval = builder.minor_scan_interval;
         let major_interval = builder.major_scan_interval;
@@ -477,7 +495,9 @@ where
         let aggregator = if aggregator {
             Some(BackgroundTask::spawn(
                 "aggregator",
-                fetcher.clone().aggregate(aggregator_metrics),
+                fetcher
+                    .clone()
+                    .aggregate(aggregator_chunk_size, aggregator_metrics),
             ))
         } else {
             None
@@ -1304,7 +1324,7 @@ where
     P: AvailabilityProvider<Types>,
 {
     #[tracing::instrument(skip_all)]
-    async fn aggregate(self: Arc<Self>, metrics: AggregatorMetrics) {
+    async fn aggregate(self: Arc<Self>, chunk_size: usize, metrics: AggregatorMetrics) {
         loop {
             let start = loop {
                 let mut tx = match self.read().await {
@@ -1327,15 +1347,29 @@ where
             tracing::info!(start, "starting aggregator");
             metrics.height.set(start);
 
-            let mut blocks = self.clone().get_range::<_, PayloadMetadata<Types>>(start..);
-            while let Some(block) = blocks.next().await {
-                let block = block.await;
-                let height = block.height();
-                tracing::debug!(height, "updating aggregate statistics for block");
+            let mut blocks = self
+                .clone()
+                .get_range_with_chunk_size::<_, PayloadMetadata<Types>>(chunk_size, start..)
+                .then(Fetch::resolve)
+                .ready_chunks(chunk_size)
+                .boxed();
+            while let Some(chunk) = blocks.next().await {
+                let Some(last) = chunk.last() else {
+                    // This is not supposed to happen, but if the chunk is empty, just skip it.
+                    tracing::warn!("ready_chunks returned an empty chunk");
+                    continue;
+                };
+                let height = last.height();
+                let num_blocks = chunk.len();
+                tracing::debug!(
+                    num_blocks,
+                    height,
+                    "updating aggregate statistics for chunk"
+                );
                 loop {
                     let res = async {
                         let mut tx = self.write().await.context("opening transaction")?;
-                        tx.update_aggregates(&block).await?;
+                        tx.update_aggregates(&chunk).await?;
                         tx.commit().await.context("committing transaction")
                     }
                     .await;
@@ -1343,8 +1377,9 @@ where
                         Ok(()) => break,
                         Err(err) => {
                             tracing::warn!(
+                                num_blocks,
                                 height,
-                                "failed to update aggregates for block: {err:#}"
+                                "failed to update aggregates for chunk: {err:#}"
                             );
                             sleep(Duration::from_secs(1)).await;
                         }

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -79,7 +79,7 @@ use super::{
         pruning::{PruneStorage, PrunedHeightStorage},
         AggregatesStorage, AvailabilityStorage, ExplorerStorage, MerklizedStateHeightStorage,
         MerklizedStateStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
-        UpdateAvailabilityStorage,
+        UpdateAvailabilityStorage, VidCommonMetadata,
     },
     Transaction, VersionedDataSource,
 };
@@ -1277,7 +1277,7 @@ where
                 // independently of the block payload.
                 let mut vid = self
                     .clone()
-                    .get_range_with_chunk_size::<_, VidCommonQueryData<Types>>(
+                    .get_range_with_chunk_size::<_, VidCommonMetadata<Types>>(
                         chunk_size,
                         start..block_height,
                     );

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -695,10 +695,10 @@ where
                 async move {
                     tracing::info!(fetch_block, fetch_vid, "fetching missing data");
                     if fetch_block {
-                        fetcher.get::<BlockQueryData<Types>>(height).await;
+                        fetcher.get::<PayloadMetadata<Types>>(height).await;
                     }
                     if fetch_vid {
-                        fetcher.get::<VidCommonQueryData<Types>>(height).await;
+                        fetcher.get::<VidCommonMetadata<Types>>(height).await;
                     }
                 }
                 .instrument(span),

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -78,16 +78,15 @@ use super::{
     storage::{
         pruning::{PruneStorage, PrunedHeightStorage},
         AggregatesStorage, AvailabilityStorage, ExplorerStorage, MerklizedStateHeightStorage,
-        MerklizedStateStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
-        UpdateAvailabilityStorage, VidCommonMetadata,
+        MerklizedStateStorage, NodeStorage, UpdateAggregatesStorage, UpdateAvailabilityStorage,
     },
     Transaction, VersionedDataSource,
 };
 use crate::{
     availability::{
         AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, LeafId, LeafQueryData,
-        PayloadQueryData, QueryableHeader, QueryablePayload, TransactionHash, TransactionQueryData,
-        UpdateAvailabilityData, VidCommonQueryData,
+        PayloadMetadata, PayloadQueryData, QueryableHeader, QueryablePayload, TransactionHash,
+        TransactionQueryData, UpdateAvailabilityData, VidCommonMetadata, VidCommonQueryData,
     },
     explorer::{self, ExplorerDataSource},
     fetching::{self, request, Provider},
@@ -569,7 +568,13 @@ where
     type PayloadRange<R> = BoxStream<'static, Fetch<PayloadQueryData<Types>>>
     where
         R: RangeBounds<usize> + Send;
+    type PayloadMetadataRange<R> = BoxStream<'static, Fetch<PayloadMetadata<Types>>>
+    where
+        R: RangeBounds<usize> + Send;
     type VidCommonRange<R> = BoxStream<'static, Fetch<VidCommonQueryData<Types>>>
+    where
+        R: RangeBounds<usize> + Send;
+    type VidCommonMetadataRange<R> = BoxStream<'static, Fetch<VidCommonMetadata<Types>>>
     where
         R: RangeBounds<usize> + Send;
 
@@ -594,7 +599,21 @@ where
         self.fetcher.get(id.into()).await
     }
 
+    async fn get_payload_metadata<ID>(&self, id: ID) -> Fetch<PayloadMetadata<Types>>
+    where
+        ID: Into<BlockId<Types>> + Send + Sync,
+    {
+        self.fetcher.get(id.into()).await
+    }
+
     async fn get_vid_common<ID>(&self, id: ID) -> Fetch<VidCommonQueryData<Types>>
+    where
+        ID: Into<BlockId<Types>> + Send + Sync,
+    {
+        self.fetcher.get(VidCommonRequest::from(id.into())).await
+    }
+
+    async fn get_vid_common_metadata<ID>(&self, id: ID) -> Fetch<VidCommonMetadata<Types>>
     where
         ID: Into<BlockId<Types>> + Send + Sync,
     {
@@ -622,7 +641,21 @@ where
         self.fetcher.clone().get_range(range)
     }
 
+    async fn get_payload_metadata_range<R>(&self, range: R) -> Self::PayloadMetadataRange<R>
+    where
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        self.fetcher.clone().get_range(range)
+    }
+
     async fn get_vid_common_range<R>(&self, range: R) -> Self::VidCommonRange<R>
+    where
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        self.fetcher.clone().get_range(range)
+    }
+
+    async fn get_vid_common_metadata_range<R>(&self, range: R) -> Self::VidCommonMetadataRange<R>
     where
         R: RangeBounds<usize> + Send + 'static,
     {

--- a/src/data_source/fetching/block.rs
+++ b/src/data_source/fetching/block.rs
@@ -18,9 +18,9 @@ use super::{
     Storable,
 };
 use crate::{
-    availability::{BlockId, BlockQueryData, PayloadQueryData, QueryablePayload},
+    availability::{BlockId, BlockQueryData, PayloadMetadata, PayloadQueryData, QueryablePayload},
     data_source::{
-        storage::{AvailabilityStorage, PayloadMetadata, UpdateAvailabilityStorage},
+        storage::{AvailabilityStorage, UpdateAvailabilityStorage},
         VersionedDataSource,
     },
     fetching::{

--- a/src/data_source/fetching/block.rs
+++ b/src/data_source/fetching/block.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::{
     availability::{BlockId, BlockQueryData, PayloadQueryData, QueryablePayload},
     data_source::{
-        storage::{AvailabilityStorage, UpdateAvailabilityStorage},
+        storage::{AvailabilityStorage, PayloadMetadata, UpdateAvailabilityStorage},
         VersionedDataSource,
     },
     fetching::{
@@ -281,5 +281,74 @@ where
         tracing::info!("fetched payload {:?}", self.header.payload_commitment());
         let block = BlockQueryData::new(self.header, payload);
         self.fetcher.store_and_notify(block).await;
+    }
+}
+
+#[async_trait]
+impl<Types> Fetchable<Types> for PayloadMetadata<Types>
+where
+    Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    type Request = BlockId<Types>;
+
+    fn satisfies(&self, req: Self::Request) -> bool {
+        match req {
+            BlockId::Number(n) => self.height == n as u64,
+            BlockId::Hash(h) => self.block_hash == h,
+            BlockId::PayloadHash(h) => self.hash == h,
+        }
+    }
+
+    async fn passive_fetch(
+        notifiers: &Notifiers<Types>,
+        req: Self::Request,
+    ) -> BoxFuture<'static, Option<Self>> {
+        notifiers
+            .block
+            .wait_for(move |block| block.satisfies(req))
+            .await
+            .into_future()
+            .map(|opt| opt.map(Self::from))
+            .boxed()
+    }
+
+    async fn active_fetch<S, P>(
+        tx: &mut impl AvailabilityStorage<Types>,
+        fetcher: Arc<Fetcher<Types, S, P>>,
+        req: Self::Request,
+    ) -> anyhow::Result<()>
+    where
+        S: VersionedDataSource + 'static,
+        for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+        P: AvailabilityProvider<Types>,
+    {
+        // Trigger the full block to be fetched. This will be enough to satisfy this request for the
+        // payload summary.
+        BlockQueryData::active_fetch(tx, fetcher, req).await
+    }
+
+    async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
+    where
+        S: AvailabilityStorage<Types>,
+    {
+        storage.get_payload_metadata(req).await
+    }
+}
+
+#[async_trait]
+impl<Types> RangedFetchable<Types> for PayloadMetadata<Types>
+where
+    Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    type RangedRequest = BlockId<Types>;
+
+    async fn load_range<S, R>(storage: &mut S, range: R) -> QueryResult<Vec<QueryResult<Self>>>
+    where
+        S: AvailabilityStorage<Types>,
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        storage.get_payload_metadata_range(range).await
     }
 }

--- a/src/data_source/fetching/vid.rs
+++ b/src/data_source/fetching/vid.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::{
     availability::{BlockId, QueryablePayload, VidCommonQueryData},
     data_source::{
-        storage::{AvailabilityStorage, UpdateAvailabilityStorage},
+        storage::{AvailabilityStorage, UpdateAvailabilityStorage, VidCommonMetadata},
         VersionedDataSource,
     },
     fetching::{self, request, Callback},
@@ -234,5 +234,73 @@ where
         tracing::info!("fetched VID common {:?}", self.header.payload_commitment());
         let common = VidCommonQueryData::new(self.header, common);
         self.fetcher.store_and_notify(common).await;
+    }
+}
+
+#[async_trait]
+impl<Types> Fetchable<Types> for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    type Request = VidCommonRequest<Types>;
+
+    fn satisfies(&self, req: Self::Request) -> bool {
+        match req.0 {
+            BlockId::Number(n) => self.height == n as u64,
+            BlockId::Hash(h) => self.block_hash == h,
+            BlockId::PayloadHash(h) => self.payload_hash == h,
+        }
+    }
+
+    async fn passive_fetch(
+        notifiers: &Notifiers<Types>,
+        req: Self::Request,
+    ) -> BoxFuture<'static, Option<Self>> {
+        notifiers
+            .vid_common
+            .wait_for(move |vid| vid.satisfies(req))
+            .await
+            .into_future()
+            .map(|opt| opt.map(Self::from))
+            .boxed()
+    }
+
+    async fn active_fetch<S, P>(
+        tx: &mut impl AvailabilityStorage<Types>,
+        fetcher: Arc<Fetcher<Types, S, P>>,
+        req: Self::Request,
+    ) where
+        S: VersionedDataSource + 'static,
+        for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
+        P: AvailabilityProvider<Types>,
+    {
+        // Trigger the full VID object to be fetched. This will be enough to satisfy this request
+        // for the summary.
+        VidCommonQueryData::active_fetch(tx, fetcher, req).await
+    }
+
+    async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>
+    where
+        S: AvailabilityStorage<Types>,
+    {
+        storage.get_vid_common_metadata(req.0).await
+    }
+}
+
+#[async_trait]
+impl<Types> RangedFetchable<Types> for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    type RangedRequest = VidCommonRequest<Types>;
+
+    async fn load_range<S, R>(storage: &mut S, range: R) -> QueryResult<Vec<QueryResult<Self>>>
+    where
+        S: AvailabilityStorage<Types>,
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        storage.get_vid_common_metadata_range(range).await
     }
 }

--- a/src/data_source/fetching/vid.rs
+++ b/src/data_source/fetching/vid.rs
@@ -18,9 +18,9 @@ use super::{
     Storable,
 };
 use crate::{
-    availability::{BlockId, QueryablePayload, VidCommonQueryData},
+    availability::{BlockId, QueryablePayload, VidCommonMetadata, VidCommonQueryData},
     data_source::{
-        storage::{AvailabilityStorage, UpdateAvailabilityStorage, VidCommonMetadata},
+        storage::{AvailabilityStorage, UpdateAvailabilityStorage},
         VersionedDataSource,
     },
     fetching::{self, request, Callback},
@@ -270,7 +270,8 @@ where
         tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         S: VersionedDataSource + 'static,
         for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
         P: AvailabilityProvider<Types>,

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -141,6 +141,42 @@ where
     }
 }
 
+/// A summary of a VID payload without all the data.
+///
+/// This is primarily useful when you want to check if a VID object exists, but not load the whole
+/// object.
+#[derive(Clone, Copy, Debug)]
+pub struct VidCommonMetadata<Types>
+where
+    Types: NodeType,
+{
+    pub height: u64,
+    pub block_hash: BlockHash<Types>,
+    pub payload_hash: VidCommitment,
+}
+
+impl<Types> HeightIndexed for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+{
+    fn height(&self) -> u64 {
+        self.height
+    }
+}
+
+impl<Types> From<VidCommonQueryData<Types>> for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+{
+    fn from(common: VidCommonQueryData<Types>) -> Self {
+        Self {
+            height: common.height(),
+            block_hash: common.block_hash(),
+            payload_hash: common.payload_hash(),
+        }
+    }
+}
+
 /// Persistent storage for a HotShot blockchain.
 ///
 /// This trait defines the interface which must be provided by the storage layer in order to
@@ -173,6 +209,10 @@ where
         &mut self,
         id: BlockId<Types>,
     ) -> QueryResult<VidCommonQueryData<Types>>;
+    async fn get_vid_common_metadata(
+        &mut self,
+        id: BlockId<Types>,
+    ) -> QueryResult<VidCommonMetadata<Types>>;
 
     async fn get_leaf_range<R>(
         &mut self,
@@ -202,6 +242,12 @@ where
         &mut self,
         range: R,
     ) -> QueryResult<Vec<QueryResult<VidCommonQueryData<Types>>>>
+    where
+        R: RangeBounds<usize> + Send + 'static;
+    async fn get_vid_common_metadata_range<R>(
+        &mut self,
+        range: R,
+    ) -> QueryResult<Vec<QueryResult<VidCommonMetadata<Types>>>>
     where
         R: RangeBounds<usize> + Send + 'static;
 

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -59,9 +59,9 @@
 
 use crate::{
     availability::{
-        BlockHash, BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData,
+        BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadMetadata, PayloadQueryData,
         QueryableHeader, QueryablePayload, TransactionHash, TransactionQueryData,
-        VidCommonQueryData,
+        VidCommonMetadata, VidCommonQueryData,
     },
     explorer::{
         query_data::{
@@ -75,8 +75,7 @@ use crate::{
     },
     merklized_state::{MerklizedState, Snapshot},
     node::{SyncStatus, TimeWindowQueryData, WindowStart},
-    types::HeightIndexed,
-    Header, Payload, QueryResult, Transaction, VidCommitment, VidShare,
+    Header, Payload, QueryResult, Transaction, VidShare,
 };
 use async_trait::async_trait;
 use futures::future::Future;
@@ -100,82 +99,6 @@ pub use fs::FileSystemStorage;
 pub use no_storage::NoStorage;
 #[cfg(feature = "sql-data-source")]
 pub use sql::SqlStorage;
-
-/// A summary of a payload without all the data.
-///
-/// This type is useful when you only want information about a payload, such as its size or
-/// transaction count, but you don't want to load the entire payload, which might be very large.
-#[derive(Clone, Copy, Debug)]
-pub struct PayloadMetadata<Types>
-where
-    Types: NodeType,
-{
-    pub height: u64,
-    pub block_hash: BlockHash<Types>,
-    pub hash: VidCommitment,
-    pub size: u64,
-    pub num_transactions: u64,
-}
-
-impl<Types> HeightIndexed for PayloadMetadata<Types>
-where
-    Types: NodeType,
-{
-    fn height(&self) -> u64 {
-        self.height
-    }
-}
-
-impl<Types> From<BlockQueryData<Types>> for PayloadMetadata<Types>
-where
-    Types: NodeType,
-{
-    fn from(block: BlockQueryData<Types>) -> Self {
-        Self {
-            height: block.height(),
-            block_hash: block.hash(),
-            hash: block.payload_hash(),
-            size: block.size(),
-            num_transactions: block.num_transactions(),
-        }
-    }
-}
-
-/// A summary of a VID payload without all the data.
-///
-/// This is primarily useful when you want to check if a VID object exists, but not load the whole
-/// object.
-#[derive(Clone, Copy, Debug)]
-pub struct VidCommonMetadata<Types>
-where
-    Types: NodeType,
-{
-    pub height: u64,
-    pub block_hash: BlockHash<Types>,
-    pub payload_hash: VidCommitment,
-}
-
-impl<Types> HeightIndexed for VidCommonMetadata<Types>
-where
-    Types: NodeType,
-{
-    fn height(&self) -> u64 {
-        self.height
-    }
-}
-
-impl<Types> From<VidCommonQueryData<Types>> for VidCommonMetadata<Types>
-where
-    Types: NodeType,
-{
-    fn from(common: VidCommonQueryData<Types>) -> Self {
-        Self {
-            height: common.height(),
-            block_hash: common.block_hash(),
-            payload_hash: common.payload_hash(),
-        }
-    }
-}
 
 /// Persistent storage for a HotShot blockchain.
 ///

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -266,7 +266,7 @@ where
     /// Update aggregate statistics based on a new block.
     fn update_aggregates(
         &mut self,
-        block: &PayloadMetadata<Types>,
+        blocks: &[PayloadMetadata<Types>],
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 

--- a/src/data_source/storage/fail_storage.rs
+++ b/src/data_source/storage/fail_storage.rs
@@ -517,8 +517,8 @@ where
     Types: NodeType,
     T: UpdateAggregatesStorage<Types> + Send + Sync,
 {
-    async fn update_aggregates(&mut self, block: &PayloadMetadata<Types>) -> anyhow::Result<()> {
+    async fn update_aggregates(&mut self, blocks: &[PayloadMetadata<Types>]) -> anyhow::Result<()> {
         self.maybe_fail_write(FailableAction::Any).await?;
-        self.inner.update_aggregates(block).await
+        self.inner.update_aggregates(blocks).await
     }
 }

--- a/src/data_source/storage/fail_storage.rs
+++ b/src/data_source/storage/fail_storage.rs
@@ -49,12 +49,14 @@ pub enum FailableAction {
     GetPayload,
     GetPayloadMetadata,
     GetVidCommon,
+    GetVidCommonMetadata,
     GetHeaderRange,
     GetLeafRange,
     GetBlockRange,
     GetPayloadRange,
     GetPayloadMetadataRange,
     GetVidCommonRange,
+    GetVidCommonMetadataRange,
     GetTransaction,
 
     /// Target any action for failure.
@@ -355,7 +357,8 @@ where
         &mut self,
         id: BlockId<Types>,
     ) -> QueryResult<VidCommonMetadata<Types>> {
-        self.maybe_fail_read().await?;
+        self.maybe_fail_read(FailableAction::GetVidCommonMetadata)
+            .await?;
         self.inner.get_vid_common_metadata(id).await
     }
 
@@ -424,7 +427,8 @@ where
     where
         R: RangeBounds<usize> + Send + 'static,
     {
-        self.maybe_fail_read().await?;
+        self.maybe_fail_read(FailableAction::GetVidCommonMetadataRange)
+            .await?;
         self.inner.get_vid_common_metadata_range(range).await
     }
 

--- a/src/data_source/storage/fail_storage.rs
+++ b/src/data_source/storage/fail_storage.rs
@@ -22,7 +22,10 @@ use crate::{
         BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryablePayload,
         TransactionHash, TransactionQueryData, VidCommonQueryData,
     },
-    data_source::{storage::PayloadMetadata, update, VersionedDataSource},
+    data_source::{
+        storage::{PayloadMetadata, VidCommonMetadata},
+        update, VersionedDataSource,
+    },
     metrics::PrometheusMetrics,
     node::{SyncStatus, TimeWindowQueryData, WindowStart},
     status::HasMetrics,
@@ -348,6 +351,14 @@ where
         self.inner.get_vid_common(id).await
     }
 
+    async fn get_vid_common_metadata(
+        &mut self,
+        id: BlockId<Types>,
+    ) -> QueryResult<VidCommonMetadata<Types>> {
+        self.maybe_fail_read().await?;
+        self.inner.get_vid_common_metadata(id).await
+    }
+
     async fn get_leaf_range<R>(
         &mut self,
         range: R,
@@ -404,6 +415,17 @@ where
         self.maybe_fail_read(FailableAction::GetVidCommonRange)
             .await?;
         self.inner.get_vid_common_range(range).await
+    }
+
+    async fn get_vid_common_metadata_range<R>(
+        &mut self,
+        range: R,
+    ) -> QueryResult<Vec<QueryResult<VidCommonMetadata<Types>>>>
+    where
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        self.maybe_fail_read().await?;
+        self.inner.get_vid_common_metadata_range(range).await
     }
 
     async fn get_transaction(

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -769,7 +769,10 @@ impl<Types, T: Revert + Send> UpdateAggregatesStorage<Types> for Transaction<T>
 where
     Types: NodeType,
 {
-    async fn update_aggregates(&mut self, _block: &PayloadMetadata<Types>) -> anyhow::Result<()> {
+    async fn update_aggregates(
+        &mut self,
+        _blocks: &[PayloadMetadata<Types>],
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -15,7 +15,7 @@
 use super::{
     ledger_log::{Iter, LedgerLog},
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
-    AggregatesStorage, AvailabilityStorage, NodeStorage, UpdateAggregatesStorage,
+    AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
     UpdateAvailabilityStorage,
 };
 
@@ -455,6 +455,13 @@ where
         self.get_block(id).await.map(PayloadQueryData::from)
     }
 
+    async fn get_payload_metadata(
+        &mut self,
+        id: BlockId<Types>,
+    ) -> QueryResult<PayloadMetadata<Types>> {
+        self.get_block(id).await.map(PayloadMetadata::from)
+    }
+
     async fn get_vid_common(
         &mut self,
         id: BlockId<Types>,
@@ -498,6 +505,18 @@ where
     {
         Ok(range_iter(self.inner.block_storage.iter(), range)
             .map(|res| res.map(PayloadQueryData::from))
+            .collect())
+    }
+
+    async fn get_payload_metadata_range<R>(
+        &mut self,
+        range: R,
+    ) -> QueryResult<Vec<QueryResult<PayloadMetadata<Types>>>>
+    where
+        R: RangeBounds<usize> + Send + 'static,
+    {
+        Ok(range_iter(self.inner.block_storage.iter(), range)
+            .map(|res| res.map(PayloadMetadata::from))
             .collect())
     }
 
@@ -750,7 +769,7 @@ impl<Types, T: Revert + Send> UpdateAggregatesStorage<Types> for Transaction<T>
 where
     Types: NodeType,
 {
-    async fn update_aggregates(&mut self, _block: &BlockQueryData<Types>) -> anyhow::Result<()> {
+    async fn update_aggregates(&mut self, _block: &PayloadMetadata<Types>) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -16,7 +16,7 @@ use super::{
     ledger_log::{Iter, LedgerLog},
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
     AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
-    UpdateAvailabilityStorage,
+    UpdateAvailabilityStorage, VidCommonMetadata,
 };
 
 use crate::{
@@ -476,6 +476,13 @@ where
             .0)
     }
 
+    async fn get_vid_common_metadata(
+        &mut self,
+        id: BlockId<Types>,
+    ) -> QueryResult<VidCommonMetadata<Types>> {
+        self.get_vid_common(id).await.map(VidCommonMetadata::from)
+    }
+
     async fn get_leaf_range<R>(
         &mut self,
         range: R,
@@ -529,6 +536,18 @@ where
     {
         Ok(range_iter(self.inner.vid_storage.iter(), range)
             .map(|res| res.map(|(common, _)| common))
+            .collect())
+    }
+
+    async fn get_vid_common_metadata_range<R>(
+        &mut self,
+        range: R,
+    ) -> QueryResult<Vec<QueryResult<VidCommonMetadata<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        Ok(range_iter(self.inner.vid_storage.iter(), range)
+            .map(|res| res.map(|(common, _)| common.into()))
             .collect())
     }
 

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -15,7 +15,7 @@
 use super::{
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
     AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
-    UpdateAvailabilityStorage,
+    UpdateAvailabilityStorage, VidCommonMetadata,
 };
 use crate::{
     availability::{
@@ -140,6 +140,13 @@ where
         Err(QueryError::Missing)
     }
 
+    async fn get_vid_common_metadata(
+        &mut self,
+        _id: BlockId<Types>,
+    ) -> QueryResult<VidCommonMetadata<Types>> {
+        Err(QueryError::Missing)
+    }
+
     async fn get_leaf_range<R>(
         &mut self,
         _range: R,
@@ -188,6 +195,16 @@ where
         R: RangeBounds<usize> + Send,
     {
         Ok(vec![])
+    }
+
+    async fn get_vid_common_metadata_range<R>(
+        &mut self,
+        _range: R,
+    ) -> QueryResult<Vec<QueryResult<VidCommonMetadata<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        Err(QueryError::Missing)
     }
 
     async fn get_transaction(

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -14,7 +14,7 @@
 
 use super::{
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
-    AggregatesStorage, AvailabilityStorage, NodeStorage, UpdateAggregatesStorage,
+    AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
     UpdateAvailabilityStorage,
 };
 use crate::{
@@ -126,6 +126,13 @@ where
         Err(QueryError::Missing)
     }
 
+    async fn get_payload_metadata(
+        &mut self,
+        _id: BlockId<Types>,
+    ) -> QueryResult<PayloadMetadata<Types>> {
+        Err(QueryError::Missing)
+    }
+
     async fn get_vid_common(
         &mut self,
         _id: BlockId<Types>,
@@ -161,6 +168,16 @@ where
         R: RangeBounds<usize> + Send,
     {
         Ok(vec![])
+    }
+
+    async fn get_payload_metadata_range<R>(
+        &mut self,
+        _range: R,
+    ) -> QueryResult<Vec<QueryResult<PayloadMetadata<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        Err(QueryError::Missing)
     }
 
     async fn get_vid_common_range<R>(
@@ -258,7 +275,7 @@ impl<'a, Types> UpdateAggregatesStorage<Types> for Transaction<'a>
 where
     Types: NodeType,
 {
-    async fn update_aggregates(&mut self, _block: &BlockQueryData<Types>) -> anyhow::Result<()> {
+    async fn update_aggregates(&mut self, _block: &PayloadMetadata<Types>) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -275,7 +275,10 @@ impl<'a, Types> UpdateAggregatesStorage<Types> for Transaction<'a>
 where
     Types: NodeType,
 {
-    async fn update_aggregates(&mut self, _block: &PayloadMetadata<Types>) -> anyhow::Result<()> {
+    async fn update_aggregates(
+        &mut self,
+        _blocks: &[PayloadMetadata<Types>],
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -184,7 +184,7 @@ where
     where
         R: RangeBounds<usize> + Send,
     {
-        Err(QueryError::Missing)
+        Ok(vec![])
     }
 
     async fn get_vid_common_range<R>(
@@ -204,7 +204,7 @@ where
     where
         R: RangeBounds<usize> + Send,
     {
-        Err(QueryError::Missing)
+        Ok(vec![])
     }
 
     async fn get_transaction(
@@ -557,7 +557,13 @@ pub mod testing {
         type PayloadRange<R> = BoxStream<'static, Fetch<PayloadQueryData<MockTypes>>>
         where
             R: RangeBounds<usize> + Send;
+        type PayloadMetadataRange<R> = BoxStream<'static, Fetch<PayloadMetadata<MockTypes>>>
+        where
+            R: RangeBounds<usize> + Send;
         type VidCommonRange<R> = BoxStream<'static, Fetch<VidCommonQueryData<MockTypes>>>
+        where
+            R: RangeBounds<usize> + Send;
+        type VidCommonMetadataRange<R> = BoxStream<'static, Fetch<VidCommonMetadata<MockTypes>>>
         where
             R: RangeBounds<usize> + Send;
 
@@ -591,6 +597,16 @@ pub mod testing {
             }
         }
 
+        async fn get_payload_metadata<ID>(&self, id: ID) -> Fetch<PayloadMetadata<MockTypes>>
+        where
+            ID: Into<BlockId<MockTypes>> + Send + Sync,
+        {
+            match self {
+                Self::Sql(data_source) => data_source.get_payload_metadata(id).await,
+                Self::NoStorage(data_source) => data_source.get_payload_metadata(id).await,
+            }
+        }
+
         async fn get_vid_common<ID>(&self, id: ID) -> Fetch<VidCommonQueryData<MockTypes>>
         where
             ID: Into<BlockId<MockTypes>> + Send + Sync,
@@ -598,6 +614,16 @@ pub mod testing {
             match self {
                 Self::Sql(data_source) => data_source.get_vid_common(id).await,
                 Self::NoStorage(data_source) => data_source.get_vid_common(id).await,
+            }
+        }
+
+        async fn get_vid_common_metadata<ID>(&self, id: ID) -> Fetch<VidCommonMetadata<MockTypes>>
+        where
+            ID: Into<BlockId<MockTypes>> + Send + Sync,
+        {
+            match self {
+                Self::Sql(data_source) => data_source.get_vid_common_metadata(id).await,
+                Self::NoStorage(data_source) => data_source.get_vid_common_metadata(id).await,
             }
         }
 
@@ -631,6 +657,20 @@ pub mod testing {
             }
         }
 
+        async fn get_payload_metadata_range<R>(&self, range: R) -> Self::PayloadMetadataRange<R>
+        where
+            R: RangeBounds<usize> + Send + 'static,
+        {
+            match self {
+                Self::Sql(data_source) => {
+                    data_source.get_payload_metadata_range(range).await.boxed()
+                }
+                Self::NoStorage(data_source) => {
+                    data_source.get_payload_metadata_range(range).await.boxed()
+                }
+            }
+        }
+
         async fn get_vid_common_range<R>(&self, range: R) -> Self::VidCommonRange<R>
         where
             R: RangeBounds<usize> + Send + 'static,
@@ -640,6 +680,25 @@ pub mod testing {
                 Self::NoStorage(data_source) => {
                     data_source.get_vid_common_range(range).await.boxed()
                 }
+            }
+        }
+
+        async fn get_vid_common_metadata_range<R>(
+            &self,
+            range: R,
+        ) -> Self::VidCommonMetadataRange<R>
+        where
+            R: RangeBounds<usize> + Send + 'static,
+        {
+            match self {
+                Self::Sql(data_source) => data_source
+                    .get_vid_common_metadata_range(range)
+                    .await
+                    .boxed(),
+                Self::NoStorage(data_source) => data_source
+                    .get_vid_common_metadata_range(range)
+                    .await
+                    .boxed(),
             }
         }
 

--- a/src/data_source/storage/sql/queries.rs
+++ b/src/data_source/storage/sql/queries.rs
@@ -18,7 +18,7 @@ use crate::{
         BlockId, BlockQueryData, LeafQueryData, PayloadQueryData, QueryablePayload,
         VidCommonQueryData,
     },
-    data_source::storage::PayloadMetadata,
+    data_source::storage::{PayloadMetadata, VidCommonMetadata},
     Header, Leaf, Payload, QueryError, QueryResult,
 };
 use anyhow::Context;
@@ -275,6 +275,30 @@ where
             block_hash,
             payload_hash,
             common,
+        })
+    }
+}
+
+const VID_COMMON_METADATA_COLUMNS: &str =
+    "h.height AS height, h.hash AS block_hash, h.payload_hash AS payload_hash";
+
+impl<'r, Types> FromRow<'r, <Db as Database>::Row> for VidCommonMetadata<Types>
+where
+    Types: NodeType,
+    Payload<Types>: QueryablePayload<Types>,
+{
+    fn from_row(row: &'r <Db as Database>::Row) -> sqlx::Result<Self> {
+        let height = row.try_get::<i64, _>("height")? as u64;
+        let block_hash: String = row.try_get("block_hash")?;
+        let block_hash = block_hash.parse().decode_error("malformed block hash")?;
+        let payload_hash: String = row.try_get("payload_hash")?;
+        let payload_hash = payload_hash
+            .parse()
+            .decode_error("malformed payload hash")?;
+        Ok(Self {
+            height,
+            block_hash,
+            payload_hash,
         })
     }
 }

--- a/src/data_source/storage/sql/queries/availability.rs
+++ b/src/data_source/storage/sql/queries/availability.rs
@@ -109,7 +109,7 @@ where
             "SELECT {PAYLOAD_METADATA_COLUMNS}
               FROM header AS h
               JOIN payload AS p ON h.height = p.height
-              WHERE {where_clause} AND p.num_transactions != NULL
+              WHERE {where_clause} AND p.num_transactions IS NOT NULL
               ORDER BY h.height ASC
               LIMIT 1"
         );

--- a/src/data_source/storage/sql/queries/availability.rs
+++ b/src/data_source/storage/sql/queries/availability.rs
@@ -15,14 +15,14 @@
 use super::{
     super::transaction::{Transaction, TransactionMode},
     QueryBuilder, BLOCK_COLUMNS, LEAF_COLUMNS, PAYLOAD_COLUMNS, PAYLOAD_METADATA_COLUMNS,
-    VID_COMMON_COLUMNS,
+    VID_COMMON_COLUMNS, VID_COMMON_METADATA_COLUMNS,
 };
 use crate::{
     availability::{
         BlockId, BlockQueryData, LeafId, LeafQueryData, PayloadQueryData, QueryableHeader,
         QueryablePayload, TransactionHash, TransactionQueryData, VidCommonQueryData,
     },
-    data_source::storage::{AvailabilityStorage, PayloadMetadata},
+    data_source::storage::{AvailabilityStorage, PayloadMetadata, VidCommonMetadata},
     types::HeightIndexed,
     ErrorSnafu, Header, MissingSnafu, Payload, QueryError, QueryResult,
 };
@@ -143,6 +143,27 @@ where
         Ok(common)
     }
 
+    async fn get_vid_common_metadata(
+        &mut self,
+        id: BlockId<Types>,
+    ) -> QueryResult<VidCommonMetadata<Types>> {
+        let mut query = QueryBuilder::default();
+        let where_clause = query.header_where_clause(id)?;
+        // ORDER BY h.height ASC ensures that if there are duplicate blocks (this can happen when
+        // selecting by payload ID, as payloads are not unique), we return the first one.
+        let sql = format!(
+            "SELECT {VID_COMMON_METADATA_COLUMNS}
+              FROM header AS h
+              JOIN vid AS v ON h.height = v.height
+              WHERE {where_clause}
+              ORDER BY h.height ASC
+              LIMIT 1"
+        );
+        let row = query.query(&sql).fetch_one(self.as_mut()).await?;
+        let common = VidCommonMetadata::from_row(&row)?;
+        Ok(common)
+    }
+
     async fn get_leaf_range<R>(
         &mut self,
         range: R,
@@ -257,6 +278,31 @@ where
             .query(&sql)
             .fetch(self.as_mut())
             .map(|res| VidCommonQueryData::from_row(&res?))
+            .map_err(QueryError::from)
+            .collect()
+            .await)
+    }
+
+    async fn get_vid_common_metadata_range<R>(
+        &mut self,
+        range: R,
+    ) -> QueryResult<Vec<QueryResult<VidCommonMetadata<Types>>>>
+    where
+        R: RangeBounds<usize> + Send,
+    {
+        let mut query = QueryBuilder::default();
+        let where_clause = query.bounds_to_where_clause(range, "h.height")?;
+        let sql = format!(
+            "SELECT {VID_COMMON_METADATA_COLUMNS}
+              FROM header AS h
+              JOIN vid AS v ON h.height = v.height
+              {where_clause}
+              ORDER BY h.height ASC"
+        );
+        Ok(query
+            .query(&sql)
+            .fetch(self.as_mut())
+            .map(|res| VidCommonMetadata::from_row(&res?))
             .map_err(QueryError::from)
             .collect()
             .await)

--- a/src/data_source/storage/sql/queries/explorer.rs
+++ b/src/data_source/storage/sql/queries/explorer.rs
@@ -414,7 +414,7 @@ where
                     h.timestamp AS timestamp,
                     h.timestamp - lead(timestamp) OVER (ORDER BY h.height DESC) AS time,
                     p.size AS size,
-                    (SELECT COUNT(*) AS transactions FROM transaction AS t WHERE t.block_height = h.height) as transactions
+                    p.num_transactions AS transactions
                 FROM header AS h
                 JOIN payload AS p ON
                     p.height = h.height
@@ -422,7 +422,8 @@ where
                     h.height IN (SELECT height FROM header ORDER BY height DESC LIMIT 50)
                 ORDER BY h.height ASC 
                 ",
-            ).fetch(self.as_mut());
+            )
+            .fetch(self.as_mut());
 
             let histograms: Result<ExplorerHistograms, sqlx::Error> = historgram_query_result
                 .map(|row_stream| {
@@ -431,7 +432,7 @@ where
                         let timestamp: i64 = row.try_get("timestamp")?;
                         let time: Option<i64> = row.try_get("time")?;
                         let size: Option<i32> = row.try_get("size")?;
-                        let num_transactions: i64 = row.try_get("transactions")?;
+                        let num_transactions: i32 = row.try_get("transactions")?;
 
                         Ok((height, timestamp, time, size, num_transactions))
                     })
@@ -444,7 +445,7 @@ where
                         block_heights: Vec::with_capacity(50),
                     },
                     |mut histograms: ExplorerHistograms,
-                     row: sqlx::Result<(i64, i64, Option<i64>, Option<i32>, i64)>| async {
+                     row: sqlx::Result<(i64, i64, Option<i64>, Option<i32>, i32)>| async {
                         let (height, _timestamp, time, size, num_transactions) = row?;
                         histograms.block_time.push(time.map(|i| i as u64));
                         histograms.block_size.push(size.map(|i| i as u64));

--- a/src/data_source/storage/sql/queries/node.rs
+++ b/src/data_source/storage/sql/queries/node.rs
@@ -17,8 +17,9 @@ use super::{
     parse_header, DecodeError, QueryBuilder, HEADER_COLUMNS,
 };
 use crate::{
-    availability::BlockQueryData,
-    data_source::storage::{AggregatesStorage, NodeStorage, UpdateAggregatesStorage},
+    data_source::storage::{
+        AggregatesStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
+    },
     node::{BlockId, SyncStatus, TimeWindowQueryData, WindowStart},
     types::HeightIndexed,
     Header, MissingSnafu, NotFoundSnafu, QueryError, QueryResult, VidShare,
@@ -275,7 +276,7 @@ impl<Mode: TransactionMode> AggregatesStorage for Transaction<Mode> {
 }
 
 impl<Types: NodeType> UpdateAggregatesStorage<Types> for Transaction<Write> {
-    async fn update_aggregates(&mut self, block: &BlockQueryData<Types>) -> anyhow::Result<()> {
+    async fn update_aggregates(&mut self, block: &PayloadMetadata<Types>) -> anyhow::Result<()> {
         let height = block.height();
         let (prev_tx_count, prev_size) = if height == 0 {
             (0, 0)
@@ -299,8 +300,8 @@ impl<Types: NodeType> UpdateAggregatesStorage<Types> for Transaction<Write> {
             ["height"],
             [(
                 height as i64,
-                (prev_tx_count + block.num_transactions()) as i64,
-                (prev_size + block.size()) as i64,
+                (prev_tx_count + block.num_transactions) as i64,
+                (prev_size + block.size) as i64,
             )],
         )
         .await

--- a/src/data_source/storage/sql/transaction.rs
+++ b/src/data_source/storage/sql/transaction.rs
@@ -521,9 +521,14 @@ where
         let payload = block.payload.encode();
         self.upsert(
             "payload",
-            ["height", "data", "size"],
+            ["height", "data", "size", "num_transactions"],
             ["height"],
-            [(block.height() as i64, payload.as_ref(), block.size() as i32)],
+            [(
+                block.height() as i64,
+                payload.as_ref(),
+                block.size() as i32,
+                block.num_transactions() as i32,
+            )],
         )
         .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,8 @@
 //! # use hotshot_query_service::{Header, QueryResult, VidShare};
 //! # use hotshot_query_service::availability::{
 //! #   AvailabilityDataSource, BlockId, BlockQueryData, Fetch, LeafId, LeafQueryData,
-//! #   PayloadQueryData, TransactionHash, TransactionQueryData, VidCommonQueryData,
+//! #   PayloadMetadata, PayloadQueryData, TransactionHash, TransactionQueryData,
+//! #   VidCommonMetadata, VidCommonQueryData,
 //! # };
 //! # use hotshot_query_service::metrics::PrometheusMetrics;
 //! # use hotshot_query_service::node::{
@@ -291,7 +292,13 @@
 //!     type PayloadRange<R> = D::PayloadRange<R>
 //!     where
 //!         R: RangeBounds<usize> + Send;
+//!     type PayloadMetadataRange<R> = D::PayloadMetadataRange<R>
+//!     where
+//!         R: RangeBounds<usize> + Send;
 //!     type VidCommonRange<R> = D::VidCommonRange<R>
+//!     where
+//!         R: RangeBounds<usize> + Send;
+//!     type VidCommonMetadataRange<R> = D::VidCommonMetadataRange<R>
 //!     where
 //!         R: RangeBounds<usize> + Send;
 //!
@@ -309,7 +316,13 @@
 //! #   async fn get_payload<ID>(&self, id: ID) -> Fetch<PayloadQueryData<AppTypes>>
 //! #   where
 //! #       ID: Into<BlockId<AppTypes>> + Send + Sync { todo!() }
+//! #   async fn get_payload_metadata<ID>(&self, id: ID) -> Fetch<PayloadMetadata<AppTypes>>
+//! #   where
+//! #       ID: Into<BlockId<AppTypes>> + Send + Sync { todo!() }
 //! #   async fn get_vid_common<ID>(&self, id: ID) -> Fetch<VidCommonQueryData<AppTypes>>
+//! #   where
+//! #       ID: Into<BlockId<AppTypes>> + Send + Sync { todo!() }
+//! #   async fn get_vid_common_metadata<ID>(&self, id: ID) -> Fetch<VidCommonMetadata<AppTypes>>
 //! #   where
 //! #       ID: Into<BlockId<AppTypes>> + Send + Sync { todo!() }
 //! #   async fn get_transaction(&self, hash: TransactionHash<AppTypes>) -> Fetch<TransactionQueryData<AppTypes>> { todo!() }
@@ -322,7 +335,13 @@
 //! #   async fn get_payload_range<R>(&self, range: R) -> Self::PayloadRange<R>
 //! #   where
 //! #       R: RangeBounds<usize> + Send { todo!() }
+//! #   async fn get_payload_metadata_range<R>(&self, range: R) -> Self::PayloadMetadataRange<R>
+//! #   where
+//! #       R: RangeBounds<usize> + Send { todo!() }
 //! #   async fn get_vid_common_range<R>(&self, range: R) -> Self::VidCommonRange<R>
+//! #   where
+//! #       R: RangeBounds<usize> + Send { todo!() }
+//! #   async fn get_vid_common_metadata_range<R>(&self, range: R) -> Self::VidCommonMetadataRange<R>
 //! #   where
 //! #       R: RangeBounds<usize> + Send { todo!() }
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,8 +574,8 @@ mod test {
     use crate::{
         availability::{
             AvailabilityDataSource, BlockId, BlockInfo, BlockQueryData, Fetch, LeafId,
-            LeafQueryData, PayloadQueryData, TransactionHash, TransactionQueryData,
-            UpdateAvailabilityData, VidCommonQueryData,
+            LeafQueryData, PayloadMetadata, PayloadQueryData, TransactionHash,
+            TransactionQueryData, UpdateAvailabilityData, VidCommonMetadata, VidCommonQueryData,
         },
         metrics::PrometheusMetrics,
         node::{NodeDataSource, SyncStatus, TimeWindowQueryData, WindowStart},
@@ -625,10 +625,22 @@ mod test {
             >>::PayloadRange<R>
         where
             R: RangeBounds<usize> + Send;
+        type PayloadMetadataRange<R> =
+            <MockDataSource as AvailabilityDataSource<
+                MockTypes,
+            >>::PayloadMetadataRange<R>
+        where
+            R: RangeBounds<usize> + Send;
         type VidCommonRange<R> =
             <MockDataSource as AvailabilityDataSource<
                 MockTypes,
             >>::VidCommonRange<R>
+        where
+            R: RangeBounds<usize> + Send;
+        type VidCommonMetadataRange<R> =
+            <MockDataSource as AvailabilityDataSource<
+                MockTypes,
+            >>::VidCommonMetadataRange<R>
         where
             R: RangeBounds<usize> + Send;
 
@@ -650,11 +662,23 @@ mod test {
         {
             self.hotshot_qs.get_payload(id).await
         }
+        async fn get_payload_metadata<ID>(&self, id: ID) -> Fetch<PayloadMetadata<MockTypes>>
+        where
+            ID: Into<BlockId<MockTypes>> + Send + Sync,
+        {
+            self.hotshot_qs.get_payload_metadata(id).await
+        }
         async fn get_vid_common<ID>(&self, id: ID) -> Fetch<VidCommonQueryData<MockTypes>>
         where
             ID: Into<BlockId<MockTypes>> + Send + Sync,
         {
             self.hotshot_qs.get_vid_common(id).await
+        }
+        async fn get_vid_common_metadata<ID>(&self, id: ID) -> Fetch<VidCommonMetadata<MockTypes>>
+        where
+            ID: Into<BlockId<MockTypes>> + Send + Sync,
+        {
+            self.hotshot_qs.get_vid_common_metadata(id).await
         }
         async fn get_leaf_range<R>(&self, range: R) -> Self::LeafRange<R>
         where
@@ -674,11 +698,26 @@ mod test {
         {
             self.hotshot_qs.get_payload_range(range).await
         }
+        async fn get_payload_metadata_range<R>(&self, range: R) -> Self::PayloadMetadataRange<R>
+        where
+            R: RangeBounds<usize> + Send + 'static,
+        {
+            self.hotshot_qs.get_payload_metadata_range(range).await
+        }
         async fn get_vid_common_range<R>(&self, range: R) -> Self::VidCommonRange<R>
         where
             R: RangeBounds<usize> + Send + 'static,
         {
             self.hotshot_qs.get_vid_common_range(range).await
+        }
+        async fn get_vid_common_metadata_range<R>(
+            &self,
+            range: R,
+        ) -> Self::VidCommonMetadataRange<R>
+        where
+            R: RangeBounds<usize> + Send + 'static,
+        {
+            self.hotshot_qs.get_vid_common_metadata_range(range).await
         }
         async fn get_transaction(
             &self,


### PR DESCRIPTION
Both the scanner and aggregator tasks wait for full blocks to be available, but neither of them actually need the full block data. The aggregator only needs a summary, and the scanner only needs to know that the block exists. It is quite wasteful to load the whole payload or VID common, which might be quite large, especially in the scanner where we really don't care about data we already have.

### This PR:
* Adds new types `PayloadMetadata` and `VidCommonMetadata`, which are like their friends `PayloadQueryData` and `VidCommonQueryData`, but without the large data blobs
* Implement fetching traits for these types which do not load the large data blob when the type is available in the local DB, but _do_ trigger a fetch of the whole object when it is missing from the local DB
* Add a column `payload.num_transactions`, so that `PayloadMetadata` can have this field, so that it is sufficient for what the aggregator task needs to do
* Modifies the aggregator and scanner tasks to use these metadata objects instead of the full objects
* Modifies the aggregator task to process blocks in batches when it is catching up, which should speed up and decrease DB load during sync

### This PR does not:
Apply the new metadata types to some explorer queries which could be substantially optimized by using them. This should be done in followup work.
