### PR TITLE
Improve robustness of fetches during database instability

### DIFF
--- a/src/data_source/fetching/block.rs
+++ b/src/data_source/fetching/block.rs
@@ -85,7 +85,8 @@ where
         tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         S: VersionedDataSource + 'static,
         for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
         P: AvailabilityProvider<Types>,
@@ -204,7 +205,8 @@ where
         tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         S: VersionedDataSource + 'static,
         for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
         P: AvailabilityProvider<Types>,

--- a/src/data_source/fetching/leaf.rs
+++ b/src/data_source/fetching/leaf.rs
@@ -81,12 +81,14 @@ where
         _tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         S: VersionedDataSource + 'static,
         for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
         P: AvailabilityProvider<Types>,
     {
-        fetch_leaf_with_callbacks(fetcher, req, None)
+        fetch_leaf_with_callbacks(fetcher, req, None);
+        Ok(())
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>

--- a/src/data_source/fetching/transaction.rs
+++ b/src/data_source/fetching/transaction.rs
@@ -66,7 +66,8 @@ where
         _tx: &mut impl AvailabilityStorage<Types>,
         _fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         S: VersionedDataSource + 'static,
         for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
         P: AvailabilityProvider<Types>,
@@ -75,6 +76,7 @@ where
         // no way of knowing whether a block with such a transaction actually exists, and we don't
         // want to bother peers with requests for non-existant transactions.
         tracing::debug!("not fetching unknown transaction {req:?}");
+        Ok(())
     }
 
     async fn load<S>(storage: &mut S, req: Self::Request) -> QueryResult<Self>

--- a/src/data_source/fetching/vid.rs
+++ b/src/data_source/fetching/vid.rs
@@ -88,7 +88,8 @@ where
         tx: &mut impl AvailabilityStorage<Types>,
         fetcher: Arc<Fetcher<Types, S, P>>,
         req: Self::Request,
-    ) where
+    ) -> anyhow::Result<()>
+    where
         S: VersionedDataSource + 'static,
         for<'a> S::Transaction<'a>: UpdateAvailabilityStorage<Types>,
         P: AvailabilityProvider<Types>,

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -140,7 +140,7 @@ where
     where
         R: RangeBounds<usize> + Send,
     {
-        Err(QueryError::Missing)
+        Ok(vec![])
     }
 
     async fn get_block_range<R>(
@@ -150,7 +150,7 @@ where
     where
         R: RangeBounds<usize> + Send,
     {
-        Err(QueryError::Missing)
+        Ok(vec![])
     }
 
     async fn get_payload_range<R>(
@@ -160,7 +160,7 @@ where
     where
         R: RangeBounds<usize> + Send,
     {
-        Err(QueryError::Missing)
+        Ok(vec![])
     }
 
     async fn get_vid_common_range<R>(
@@ -170,7 +170,7 @@ where
     where
         R: RangeBounds<usize> + Send,
     {
-        Err(QueryError::Missing)
+        Ok(vec![])
     }
 
     async fn get_transaction(

--- a/src/fetching.rs
+++ b/src/fetching.rs
@@ -39,8 +39,6 @@ pub mod request;
 pub use provider::Provider;
 pub use request::Request;
 
-const DEFAULT_RATE_LIMIT: usize = 32;
-
 /// A callback to process the result of a request.
 ///
 /// Sometimes, we may fetch the same object for multiple purposes, so a request may have more than
@@ -68,25 +66,13 @@ pub struct Fetcher<T, C> {
     permit: Arc<Semaphore>,
 }
 
-impl<T, C> Default for Fetcher<T, C> {
-    fn default() -> Self {
+impl<T, C> Fetcher<T, C> {
+    pub fn new(permit: Arc<Semaphore>, backoff: ExponentialBackoff) -> Self {
         Self {
             in_progress: Default::default(),
-            backoff: Default::default(),
-            permit: Arc::new(Semaphore::new(DEFAULT_RATE_LIMIT)),
+            permit,
+            backoff,
         }
-    }
-}
-
-impl<T, C> Fetcher<T, C> {
-    pub fn with_backoff(mut self, backoff: ExponentialBackoff) -> Self {
-        self.backoff = backoff;
-        self
-    }
-
-    pub fn with_rate_limit(mut self, permit: Arc<Semaphore>) -> Self {
-        self.permit = permit;
-        self
     }
 }
 


### PR DESCRIPTION
We have observed on Mainnet that when the database is having errors (such as performance issues leading to timeouts acquiring a connection), some fetches never return, because we erroneously believe an object is missing and wait for, when really it was just temporarily inaccessible and no one is fetching it.

### This PR:

* Makes low-level fetching-related functions fallible, so we can more easily distinguish between an object being missing vs temporarily inaccessilbe
* Retries fetch initialization until we successfully trigger the fetch

The guarantee that this change upholds is that every fetch will eventually resolve as long as the requested object is either fetchable or exists in the database already.

See commit messages, comments and new tests for additional details.
