### PR TITLE
Limit size of ranges in range queries

### DIFF
--- a/api/availability.toml
+++ b/api/availability.toml
@@ -72,6 +72,9 @@ PATH = ["leaf/:from/:until"]
 DOC = """
 Get the leaves based on their position in the ledger,
 the leaves are taken starting from the given :from up until the given :until.
+
+The allowable length of the requested range may be restricted by an implementation-defined limit
+(see `/limits`). Requests for ranges exceeding these limits will fail with a 400 status code.
 """
 
 [route.stream_leaves]
@@ -102,6 +105,9 @@ PATH = ["header/:from/:until"]
 DOC = """
 Get the headers based on their position in the ledger,
 the headers are taken starting from the given :from up until the given :until.
+
+The allowable length of the requested range may be restricted by an implementation-defined limit
+(see `/limits`). Requests for ranges exceeding these limits will fail with a 400 status code.
 """
 
 [route.stream_headers]
@@ -147,6 +153,9 @@ PATH = ["block/:from/:until"]
 DOC = """
 Get the blocks based on their position in the ledger,
 the blocks are taken starting from the given :from up until the given :until.
+
+The allowable length of the requested range may be restricted by an implementation-defined limit
+(see `/limits`). Requests for ranges exceeding these limits will fail with a 400 status code.
 """
 
 [route.stream_blocks]
@@ -175,6 +184,9 @@ PATH = ["payload/:from/:until"]
 DOC = """
 Get the payloads of blocks based on their position in the ledger,
 the payloads are taken starting from the given :from up until the given :until.
+
+The allowable length of the requested range may be restricted by an implementation-defined limit
+(see `/limits`). Requests for ranges exceeding these limits will fail with a 400 status code.
 """
 
 [route.stream_payloads]
@@ -276,4 +288,37 @@ PATH = ["block/summaries/:from/:until"]
 DOC = """
 Get the Block Summary entries for blocks based on their position in the ledger,
 the blocks are taken starting from the given :from up until the given :until.
+
+The allowable length of the requested range may be restricted by an implementation-defined limit
+(see `/limits`). Requests for ranges exceeding these limits will fail with a 400 status code.
+"""
+
+[route.get_limits]
+PATH = ["limits"]
+DOC = """
+Get implementation-defined limits restricting certain requests.
+
+* `small_object_range_limit`: the maximum number of small objects which can be loaded in a single
+  range query.
+
+  Currently small objects include leaves only. In the future this limit will also apply to headers,
+  block summaries, and VID common, however
+  - loading of headers and block summaries is currently implemented by loading the entire block
+  - imperfect VID parameter tuning means that VID common can be much larger than it should
+
+* `large_object_range_limit`: the maximum number of large objects which can be loaded in a single
+  range query.
+
+  Large objects include anything that _might_ contain a full payload or an object proportional in
+  size to a payload. Note that this limit applies to the entire class of objects: we do not check
+  the size of objects while loading to determine which limit to apply. If an object belongs to a
+  class which might contain a large payload, the large object limit always applies.
+
+Returns
+```
+{
+    "large_object_range_limit": integer,
+    "small_object_range_limit": integer
+}
+```
 """

--- a/api/node.toml
+++ b/api/node.toml
@@ -118,6 +118,12 @@ indicate that the response is not complete. The client can then use one of the `
 this endpoint to fetch the remaining blocks from where the first response left off, once they become
 available. If no blocks are available, not even `prev`, this endpoint will return an error.
 
+It is also possible that the number of blocks returned may be restricted by an implementation-
+defined limit (see `/limits`), even if subsequent blocks within the window are currently available.
+In this case, `next` will be `null` and the client should call again using one of the `/from/` forms
+to get the next page of results, exactly as in the case where some blocks in the window have yet to
+be produced.
+
 Returns
 
 ```json
@@ -129,4 +135,20 @@ Returns
 ```
 
 All timestamps are denominated in an integer number of seconds.
+"""
+
+[route.get_limits]
+PATH = ["limits"]
+DOC = """
+Get implementation-defined limits restricting certain requests.
+
+* `window_limit`: the maximum number of headers which can be loaded in a single `header/window`
+  query.
+
+Returns
+```
+{
+    "window_limit": integer
+}
+```
 """

--- a/src/availability/query_data.rs
+++ b/src/availability/query_data.rs
@@ -717,3 +717,9 @@ where
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Limits {
+    pub small_object_range_limit: usize,
+    pub large_object_range_limit: usize,
+}

--- a/src/data_source/extension.rs
+++ b/src/data_source/extension.rs
@@ -289,8 +289,9 @@ where
         &self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
+        limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
-        self.data_source.get_header_window(start, end).await
+        self.data_source.get_header_window(start, end, limit).await
     }
 }
 

--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -1666,11 +1666,12 @@ where
         &self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
+        limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
         let mut tx = self.read().await.map_err(|err| QueryError::Error {
             message: err.to_string(),
         })?;
-        tx.get_header_window(start, end).await
+        tx.get_header_window(start, end, limit).await
     }
 }
 

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -217,6 +217,7 @@ pub trait NodeStorage<Types: NodeType> {
         &mut self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
+        limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>>;
 
     /// Search the database for missing objects and generate a report.

--- a/src/data_source/storage/fail_storage.rs
+++ b/src/data_source/storage/fail_storage.rs
@@ -522,9 +522,10 @@ where
         &mut self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
+        limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
         self.maybe_fail_read(FailableAction::Any).await?;
-        self.inner.get_header_window(start, end).await
+        self.inner.get_header_window(start, end, limit).await
     }
 }
 

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -734,6 +734,7 @@ where
         &mut self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
+        limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
         let first_block = match start.into() {
             WindowStart::Height(h) => h,
@@ -772,6 +773,9 @@ where
                 break;
             }
             res.window.push(header);
+            if res.window.len() >= limit {
+                break;
+            }
         }
 
         Ok(res)

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -277,6 +277,7 @@ where
         &mut self,
         _start: impl Into<WindowStart<Types>> + Send + Sync,
         _end: u64,
+        _limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>> {
         Err(QueryError::Missing)
     }
@@ -770,10 +771,11 @@ pub mod testing {
             &mut self,
             start: impl Into<WindowStart<MockTypes>> + Send + Sync,
             end: u64,
+            limit: usize,
         ) -> QueryResult<TimeWindowQueryData<Header<MockTypes>>> {
             match self {
-                Transaction::Sql(tx) => tx.get_header_window(start, end).await,
-                Transaction::NoStorage(tx) => tx.get_header_window(start, end).await,
+                Transaction::Sql(tx) => tx.get_header_window(start, end, limit).await,
+                Transaction::NoStorage(tx) => tx.get_header_window(start, end, limit).await,
             }
         }
     }
@@ -855,11 +857,14 @@ pub mod testing {
             &self,
             start: impl Into<WindowStart<MockTypes>> + Send + Sync,
             end: u64,
+            limit: usize,
         ) -> QueryResult<TimeWindowQueryData<Header<MockTypes>>> {
             match self {
-                DataSource::Sql(data_source) => data_source.get_header_window(start, end).await,
+                DataSource::Sql(data_source) => {
+                    data_source.get_header_window(start, end, limit).await
+                }
                 DataSource::NoStorage(data_source) => {
-                    data_source.get_header_window(start, end).await
+                    data_source.get_header_window(start, end, limit).await
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,8 +382,9 @@
 //!         &self,
 //!         start: impl Into<WindowStart<AppTypes>> + Send + Sync,
 //!         end: u64,
+//!         limit: usize,
 //!     ) -> QueryResult<TimeWindowQueryData<Header<AppTypes>>> {
-//!         self.hotshot_qs.get_header_window(start, end).await
+//!         self.hotshot_qs.get_header_window(start, end, limit).await
 //!     }
 //! }
 //!
@@ -777,8 +778,9 @@ mod test {
             &self,
             start: impl Into<WindowStart<MockTypes>> + Send + Sync,
             end: u64,
+            limit: usize,
         ) -> QueryResult<TimeWindowQueryData<Header<MockTypes>>> {
-            self.hotshot_qs.get_header_window(start, end).await
+            self.hotshot_qs.get_header_window(start, end, limit).await
         }
     }
 

--- a/src/node/data_source.rs
+++ b/src/node/data_source.rs
@@ -66,6 +66,7 @@ pub trait NodeDataSource<Types: NodeType> {
         &self,
         start: impl Into<WindowStart<Types>> + Send + Sync,
         end: u64,
+        limit: usize,
     ) -> QueryResult<TimeWindowQueryData<Header<Types>>>;
 
     /// Search the database for missing objects and generate a report.

--- a/src/node/query_data.rs
+++ b/src/node/query_data.rs
@@ -61,3 +61,8 @@ impl<T: HeightIndexed> TimeWindowQueryData<T> {
             .map(|t| t.height())
     }
 }
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Limits {
+    pub window_limit: usize,
+}


### PR DESCRIPTION
Fixes a vulnerability where a client can request an arbitrarily large range of objects, forcing the server to make a very expensive SQL query and load a large amount of data into memory. We now put a hard limit on availability range queries and the header timestamp window query.