### PR TITLE
separate transactions when updating aggregates

### DIFF
--- a/src/data_source/fetching.rs
+++ b/src/data_source/fetching.rs
@@ -1360,24 +1360,30 @@ where
     #[tracing::instrument(skip_all)]
     async fn aggregate(self: Arc<Self>, chunk_size: usize, metrics: AggregatorMetrics) {
         loop {
-            let start = loop {
+            let prev_aggregate = loop {
                 let mut tx = match self.read().await {
                     Ok(tx) => tx,
                     Err(err) => {
-                        tracing::error!("unable to start aggregator: {err:#}");
+                        tracing::error!("unable to open read tx: {err:#}");
                         sleep(Duration::from_secs(5)).await;
                         continue;
                     }
                 };
-                match tx.aggregates_height().await {
-                    Ok(height) => break height,
+                match tx.load_prev_aggregate().await {
+                    Ok(agg) => break agg,
                     Err(err) => {
-                        tracing::error!("unable to load aggregator height: {err:#}");
+                        tracing::error!("unable to load previous aggregate: {err:#}");
                         sleep(Duration::from_secs(5)).await;
                         continue;
                     }
-                };
+                }
             };
+
+            let (start, mut prev_aggregate) = match prev_aggregate {
+                Some(aggregate) => (aggregate.height as usize + 1, aggregate),
+                None => (0, Aggregate::default()),
+            };
+
             tracing::info!(start, "starting aggregator");
             metrics.height.set(start);
 
@@ -1402,21 +1408,18 @@ where
                 );
                 loop {
                     let res = async {
-                        let start = chunk[0].height;
-                        let aggregate = if start == 0 {
-                            Aggregate::default()
-                        } else {
-                            let mut tx = self.read().await.context("opening transaction")?;
-                            tx.aggregate((start - 1).try_into()?).await?
-                        };
-
                         let mut tx = self.write().await.context("opening transaction")?;
-                        tx.update_aggregates(aggregate, &chunk).await?;
-                        tx.commit().await.context("committing transaction")
+                        let aggregate =
+                            tx.update_aggregates(prev_aggregate.clone(), &chunk).await?;
+                        tx.commit().await.context("committing transaction")?;
+                        prev_aggregate = aggregate;
+                        anyhow::Result::<_>::Ok(())
                     }
                     .await;
                     match res {
-                        Ok(()) => break,
+                        Ok(()) => {
+                            break;
+                        }
                         Err(err) => {
                             tracing::warn!(
                                 num_blocks,

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -235,8 +235,10 @@ pub trait AggregatesStorage {
     /// The block height for which aggregate statistics are currently available.
     fn aggregates_height(&mut self) -> impl Future<Output = anyhow::Result<usize>> + Send;
 
-    /// The aggregate table row at a specific block height
-    fn aggregate(&mut self, height: i64) -> impl Future<Output = anyhow::Result<Aggregate>> + Send;
+    /// the last aggregate
+    fn load_prev_aggregate(
+        &mut self,
+    ) -> impl Future<Output = anyhow::Result<Option<Aggregate>>> + Send;
 }
 
 pub trait UpdateAggregatesStorage<Types>
@@ -248,7 +250,7 @@ where
         &mut self,
         aggregate: Aggregate,
         blocks: &[PayloadMetadata<Types>],
-    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+    ) -> impl Future<Output = anyhow::Result<Aggregate>> + Send;
 }
 
 /// An interface for querying Data and Statistics from the HotShot Blockchain.

--- a/src/data_source/storage.rs
+++ b/src/data_source/storage.rs
@@ -81,7 +81,6 @@ use async_trait::async_trait;
 use futures::future::Future;
 use hotshot_types::traits::node_implementation::NodeType;
 use jf_merkle_tree::prelude::MerkleProof;
-use sqlx::prelude::FromRow;
 use std::ops::RangeBounds;
 use tagged_base64::TaggedBase64;
 
@@ -225,7 +224,7 @@ pub trait NodeStorage<Types: NodeType> {
     async fn sync_status(&mut self) -> QueryResult<SyncStatus>;
 }
 
-#[derive(Clone, Debug, Default, FromRow)]
+#[derive(Clone, Debug, Default)]
 pub struct Aggregate {
     pub height: i64,
     pub num_transactions: i64,

--- a/src/data_source/storage/fail_storage.rs
+++ b/src/data_source/storage/fail_storage.rs
@@ -14,7 +14,7 @@
 
 use super::{
     pruning::{PruneStorage, PrunedHeightStorage, PrunerCfg, PrunerConfig},
-    AggregatesStorage, AvailabilityStorage, NodeStorage, UpdateAggregatesStorage,
+    Aggregate, AggregatesStorage, AvailabilityStorage, NodeStorage, UpdateAggregatesStorage,
     UpdateAvailabilityStorage,
 };
 use crate::{
@@ -537,6 +537,11 @@ where
         self.maybe_fail_read(FailableAction::Any).await?;
         self.inner.aggregates_height().await
     }
+
+    async fn aggregate(&mut self, height: i64) -> anyhow::Result<Aggregate> {
+        self.maybe_fail_read(FailableAction::Any).await?;
+        self.inner.aggregate(height).await
+    }
 }
 
 impl<T, Types> UpdateAggregatesStorage<Types> for Transaction<T>
@@ -544,8 +549,12 @@ where
     Types: NodeType,
     T: UpdateAggregatesStorage<Types> + Send + Sync,
 {
-    async fn update_aggregates(&mut self, blocks: &[PayloadMetadata<Types>]) -> anyhow::Result<()> {
+    async fn update_aggregates(
+        &mut self,
+        aggregate: Aggregate,
+        blocks: &[PayloadMetadata<Types>],
+    ) -> anyhow::Result<()> {
         self.maybe_fail_write(FailableAction::Any).await?;
-        self.inner.update_aggregates(blocks).await
+        self.inner.update_aggregates(aggregate, blocks).await
     }
 }

--- a/src/data_source/storage/fail_storage.rs
+++ b/src/data_source/storage/fail_storage.rs
@@ -538,9 +538,9 @@ where
         self.inner.aggregates_height().await
     }
 
-    async fn aggregate(&mut self, height: i64) -> anyhow::Result<Aggregate> {
+    async fn load_prev_aggregate(&mut self) -> anyhow::Result<Option<Aggregate>> {
         self.maybe_fail_read(FailableAction::Any).await?;
-        self.inner.aggregate(height).await
+        self.inner.load_prev_aggregate().await
     }
 }
 
@@ -551,10 +551,10 @@ where
 {
     async fn update_aggregates(
         &mut self,
-        aggregate: Aggregate,
+        prev: Aggregate,
         blocks: &[PayloadMetadata<Types>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Aggregate> {
         self.maybe_fail_write(FailableAction::Any).await?;
-        self.inner.update_aggregates(aggregate, blocks).await
+        self.inner.update_aggregates(prev, blocks).await
     }
 }

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -15,8 +15,8 @@
 use super::{
     ledger_log::{Iter, LedgerLog},
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
-    AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
-    UpdateAvailabilityStorage, VidCommonMetadata,
+    Aggregate, AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata,
+    UpdateAggregatesStorage, UpdateAvailabilityStorage, VidCommonMetadata,
 };
 
 use crate::{
@@ -786,6 +786,10 @@ impl<T: Revert + Send> AggregatesStorage for Transaction<T> {
     async fn aggregates_height(&mut self) -> anyhow::Result<usize> {
         Ok(0)
     }
+
+    async fn aggregate(&mut self, _height: i64) -> anyhow::Result<Aggregate> {
+        Ok(Aggregate::default())
+    }
 }
 
 impl<Types, T: Revert + Send> UpdateAggregatesStorage<Types> for Transaction<T>
@@ -794,6 +798,7 @@ where
 {
     async fn update_aggregates(
         &mut self,
+        _aggregate: Aggregate,
         _blocks: &[PayloadMetadata<Types>],
     ) -> anyhow::Result<()> {
         Ok(())

--- a/src/data_source/storage/fs.rs
+++ b/src/data_source/storage/fs.rs
@@ -787,8 +787,8 @@ impl<T: Revert + Send> AggregatesStorage for Transaction<T> {
         Ok(0)
     }
 
-    async fn aggregate(&mut self, _height: i64) -> anyhow::Result<Aggregate> {
-        Ok(Aggregate::default())
+    async fn load_prev_aggregate(&mut self) -> anyhow::Result<Option<Aggregate>> {
+        Ok(None)
     }
 }
 
@@ -798,10 +798,10 @@ where
 {
     async fn update_aggregates(
         &mut self,
-        _aggregate: Aggregate,
+        _prev: Aggregate,
         _blocks: &[PayloadMetadata<Types>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<Aggregate> {
+        Ok(Aggregate::default())
     }
 }
 

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -14,8 +14,8 @@
 
 use super::{
     pruning::{PruneStorage, PrunedHeightStorage, PrunerConfig},
-    AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
-    UpdateAvailabilityStorage, VidCommonMetadata,
+    Aggregate, AggregatesStorage, AvailabilityStorage, NodeStorage, PayloadMetadata,
+    UpdateAggregatesStorage, UpdateAvailabilityStorage, VidCommonMetadata,
 };
 use crate::{
     availability::{
@@ -287,6 +287,10 @@ impl<'a> AggregatesStorage for Transaction<'a> {
     async fn aggregates_height(&mut self) -> anyhow::Result<usize> {
         bail!("no_storage mock read error")
     }
+
+    async fn aggregate(&mut self, _height: i64) -> anyhow::Result<Aggregate> {
+        bail!("no_storage mock read error")
+    }
 }
 
 impl<'a, Types> UpdateAggregatesStorage<Types> for Transaction<'a>
@@ -295,6 +299,7 @@ where
 {
     async fn update_aggregates(
         &mut self,
+        _aggregate: Aggregate,
         _blocks: &[PayloadMetadata<Types>],
     ) -> anyhow::Result<()> {
         Ok(())

--- a/src/data_source/storage/no_storage.rs
+++ b/src/data_source/storage/no_storage.rs
@@ -288,7 +288,7 @@ impl<'a> AggregatesStorage for Transaction<'a> {
         bail!("no_storage mock read error")
     }
 
-    async fn aggregate(&mut self, _height: i64) -> anyhow::Result<Aggregate> {
+    async fn load_prev_aggregate(&mut self) -> anyhow::Result<Option<Aggregate>> {
         bail!("no_storage mock read error")
     }
 }
@@ -299,10 +299,10 @@ where
 {
     async fn update_aggregates(
         &mut self,
-        _aggregate: Aggregate,
+        _prev: Aggregate,
         _blocks: &[PayloadMetadata<Types>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<Aggregate> {
+        Ok(Aggregate::default())
     }
 }
 

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -917,14 +917,7 @@ pub mod testing {
 
         pub fn config(&self) -> Config {
             #[cfg(feature = "embedded-db")]
-            let mut cfg: Config = {
-                let db_path = self.db_path.to_string_lossy();
-                let path = format!("sqlite:{db_path}");
-                sqlx::sqlite::SqliteConnectOptions::from_str(&path)
-                    .expect("invalid db path")
-                    .create_if_missing(true)
-                    .into()
-            };
+            let mut cfg = Config::default().db_path(self.db_path.clone());
 
             #[cfg(not(feature = "embedded-db"))]
             let mut cfg = Config::default()

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -922,7 +922,6 @@ pub mod testing {
                 let path = format!("sqlite:{db_path}");
                 sqlx::sqlite::SqliteConnectOptions::from_str(&path)
                     .expect("invalid db path")
-                    .locking_mode(sqlx::sqlite::SqliteLockingMode::Exclusive)
                     .create_if_missing(true)
                     .into()
             };

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -922,7 +922,7 @@ pub mod testing {
                 let path = format!("sqlite:{db_path}");
                 sqlx::sqlite::SqliteConnectOptions::from_str(&path)
                     .expect("invalid db path")
-                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+                    .locking_mode(sqlx::sqlite::SqliteLockingMode::Exclusive)
                     .create_if_missing(true)
                     .into()
             };

--- a/src/data_source/storage/sql.rs
+++ b/src/data_source/storage/sql.rs
@@ -922,6 +922,7 @@ pub mod testing {
                 let path = format!("sqlite:{db_path}");
                 sqlx::sqlite::SqliteConnectOptions::from_str(&path)
                     .expect("invalid db path")
+                    .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
                     .create_if_missing(true)
                     .into()
             };

--- a/src/data_source/storage/sql/queries/node.rs
+++ b/src/data_source/storage/sql/queries/node.rs
@@ -336,22 +336,23 @@ impl<Types: NodeType> UpdateAggregatesStorage<Types> for Transaction<Write> {
                 },
             )
             .collect::<anyhow::Result<Vec<_>>>()?;
+        let last_aggregate = rows.last().cloned();
 
         self.upsert(
             "aggregate",
             ["height", "num_transactions", "payload_size"],
             ["height"],
-            rows.clone(),
+            rows,
         )
         .await?;
 
         let (height, num_transactions, payload_size) =
-            rows.last().ok_or_else(|| anyhow!("no row"))?;
+            last_aggregate.ok_or_else(|| anyhow!("no row"))?;
 
         Ok(Aggregate {
-            height: *height,
-            num_transactions: *num_transactions,
-            payload_size: *payload_size,
+            height,
+            num_transactions,
+            payload_size,
         })
     }
 }

--- a/src/data_source/storage/sql/queries/node.rs
+++ b/src/data_source/storage/sql/queries/node.rs
@@ -288,12 +288,18 @@ impl<Mode: TransactionMode> AggregatesStorage for Transaction<Mode> {
     }
 
     async fn aggregate(&mut self, height: i64) -> anyhow::Result<Aggregate> {
-        let aggregate = query_as("SELECT * FROM aggregate WHERE height = $1")
-            .bind(height)
-            .fetch_one(self.as_mut())
-            .await?;
+        let (height, num_transactions, payload_size) = query_as(
+            "SELECT height, num_transactions, payload_size FROM aggregate WHERE height = $1",
+        )
+        .bind(height)
+        .fetch_one(self.as_mut())
+        .await?;
 
-        Ok(aggregate)
+        Ok(Aggregate {
+            height,
+            num_transactions,
+            payload_size,
+        })
     }
 }
 

--- a/src/data_source/storage/sql/queries/node.rs
+++ b/src/data_source/storage/sql/queries/node.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     data_source::storage::{
-        AggregatesStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
+        Aggregate, AggregatesStorage, NodeStorage, PayloadMetadata, UpdateAggregatesStorage,
     },
     node::{BlockId, SyncStatus, TimeWindowQueryData, WindowStart},
     types::HeightIndexed,
@@ -286,28 +286,28 @@ impl<Mode: TransactionMode> AggregatesStorage for Transaction<Mode> {
             .await?;
         Ok(height as usize)
     }
+
+    async fn aggregate(&mut self, height: i64) -> anyhow::Result<Aggregate> {
+        let aggregate = query_as("SELECT * FROM aggregate WHERE height = $1")
+            .bind(height)
+            .fetch_one(self.as_mut())
+            .await?;
+
+        Ok(aggregate)
+    }
 }
 
 impl<Types: NodeType> UpdateAggregatesStorage<Types> for Transaction<Write> {
-    async fn update_aggregates(&mut self, blocks: &[PayloadMetadata<Types>]) -> anyhow::Result<()> {
-        // Get the cumulative statistics up to the block before this chunk.
+    async fn update_aggregates(
+        &mut self,
+        aggregate: Aggregate,
+        blocks: &[PayloadMetadata<Types>],
+    ) -> anyhow::Result<()> {
         let height = blocks[0].height();
-        let (prev_tx_count, prev_size) = if height == 0 {
-            (0, 0)
-        } else {
-            let (tx_count, size): (i64, i64) =
-                query_as("SELECT num_transactions, payload_size FROM aggregate WHERE height = $1")
-                    .bind((height - 1) as i64)
-                    .fetch_one(self.as_mut())
-                    .await
-                    .map_err(|err| {
-                        anyhow::Error::new(err).context(format!(
-                    "cannot update aggregates for block {height} because previous block is missing"
-                ))
-                    })?;
-            (tx_count as u64, size as u64)
-        };
-
+        let (prev_tx_count, prev_size) = (
+            aggregate.num_transactions as u64,
+            aggregate.payload_size as u64,
+        );
         // Cumulatively sum up new statistics for each block in this chunk.
         let rows = blocks
             .iter()

--- a/src/fetching/provider/query_service.rs
+++ b/src/fetching/provider/query_service.rs
@@ -1135,8 +1135,6 @@ mod test {
         tracing::info!("retrieve from storage");
         let fetch = data_source.get_leaf(1).await;
         assert_eq!(leaves[0], fetch.try_resolve().ok().unwrap());
-
-        drop(db);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/fetching/provider/query_service.rs
+++ b/src/fetching/provider/query_service.rs
@@ -1124,12 +1124,20 @@ mod test {
         assert_eq!(leaves[0], data_source.get_leaf(1).await.await);
         data_source.as_ref().pass().await;
 
+        // It is possible that the fetch above completes, notifies the subscriber,
+        // and the fetch below quickly subscribes and gets notified by the same loop.
+        // We add a delay here to avoid this situation.
+        // This is not a bug, as being notified after subscribing is fine.
+        sleep(Duration::from_secs(1)).await;
+
         // We can get the same leaf again, this will again trigger an active fetch since storage
         // failed the first time.
         tracing::info!("fetch with write success");
         let fetch = data_source.get_leaf(1).await;
         assert!(fetch.is_pending());
         assert_eq!(leaves[0], fetch.await);
+
+        sleep(Duration::from_secs(1)).await;
 
         // Finally, we should have the leaf locally and not need to fetch it.
         tracing::info!("retrieve from storage");


### PR DESCRIPTION
I am seeing a lot of database locking errors for sqlite during the update of aggregates. I tried separating the read transaction for the aggregate count from the write transaction, and the locking errors are gone. However, I am not sure why this is happening.