### PR TITLE
fix: gate no_storage import within test scope

### DIFF
--- a/src/availability.rs
+++ b/src/availability.rs
@@ -499,7 +499,7 @@ fn enforce_range_limit(from: usize, until: usize, limit: usize) -> Result<(), Er
 mod test {
     use super::*;
     use crate::{
-        data_source::{storage::no_storage, ExtensibleDataSource},
+        data_source::ExtensibleDataSource,
         status::StatusDataSource,
         task::BackgroundTask,
         testing::{
@@ -781,9 +781,10 @@ mod test {
     }
 
     // This test runs the `postgres` Docker image, which doesn't work on Windows.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), feature = "no-storage"))]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_api_no_storage() {
+        use crate::data_source::storage::no_storage;
         // With a long enough fetch timeout, we can run the API without any local storage and it
         // still works: missing data is fetched on demand or proactively from a peer.
         //


### PR DESCRIPTION
### This PR:
* Fixes linter errors by properly gating `no_storage` import within test scope
* Ensures `no_storage` module is only imported when the feature flag is enabled

<!-- ### This PR does not: -->
<!-- No out-of-scope items to mention -->

### Key places to review:
* `src/availability.rs`
* Feature gate implementation

### Things tested
* Verified linter errors are resolved
* Confirmed all tests pass with `cargo nextest run --all-features`

### Implementation Details
The `no_storage` module is feature-gated behind `no-storage`, but was being imported at the test module level, causing linter errors when the feature was not enabled. The fix:

* Moved `no_storage` import inside the specific test that uses it
* Added feature gate to the test: `#[cfg(all(not(target_os = "windows"), feature = "no-storage"))]`
* Kept other tests in the module accessible without the feature

Previous Error:
```
unresolved import `crate::data_source::storage::no_storage`
```