### PR TITLE
feat: added tests for transaction details

### DIFF
--- a/src/availability.rs
+++ b/src/availability.rs
@@ -499,7 +499,7 @@ fn enforce_range_limit(from: usize, until: usize, limit: usize) -> Result<(), Er
 mod test {
     use super::*;
     use crate::{
-        data_source::{storage::no_storage, ExtensibleDataSource},
+        data_source::ExtensibleDataSource,
         status::StatusDataSource,
         task::BackgroundTask,
         testing::{
@@ -781,9 +781,10 @@ mod test {
     }
 
     // This test runs the `postgres` Docker image, which doesn't work on Windows.
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(not(target_os = "windows"), feature = "no-storage"))]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_api_no_storage() {
+        use crate::data_source::storage::no_storage;
         // With a long enough fetch timeout, we can run the API without any local storage and it
         // still works: missing data is fetched on demand or proactively from a peer.
         //


### PR DESCRIPTION
### This PR:
- Added tests to prevent regression of DESC ordering:
  - Referring to the previously fixed issue where DESC + OFFSET incorrectly skipped recent transactions
- Fixed query syntax compatibility between SQLite and PostgreSQL for LIMIT/OFFSET ordering

### Key places to review:
- `src/data_source/storage/sql/queries/explorer.rs`
- The written test in it
- Introduced syntax compatibility between SQLite and PostgreSQL

### Things tested
- Transaction ordering test to prevent DESC regression: 
  ```bash
  cargo nextest run test_transaction_detail_asc_ordering
  ```
- Verified with both `--all-features` and individual feature flags

### Implementation Details
- Added conditional query formatting based on database back-end
- Introduced test for ordering stays ASC to prevent re-introduction of DESC + OFFSET bug that caused incorrect transaction skipping

Previous Error ( in the introduced test prior additionally addressing query compatibility ):
```
near OFFSET: syntax error
```